### PR TITLE
Add altimeter units and leave unit conversion up to the user

### DIFF
--- a/src/command/metar/AltimeterCommand.ts
+++ b/src/command/metar/AltimeterCommand.ts
@@ -1,5 +1,6 @@
 import { UnexpectedParseError } from "commons/errors";
 import { IMetar } from "model/model";
+import { AltimeterUnit } from "model/enum";
 import { ICommand } from "../metar";
 
 export class AltimeterCommand implements ICommand {
@@ -14,6 +15,9 @@ export class AltimeterCommand implements ICommand {
 
     if (!matches) throw new UnexpectedParseError("Match not found");
 
-    metar.altimeter = Math.trunc(+matches[1]);
+    metar.altimeter = {
+      value: +matches[1],
+      unit: AltimeterUnit.HPa,
+    };
   }
 }

--- a/src/command/metar/AltimeterMercuryCommand.ts
+++ b/src/command/metar/AltimeterMercuryCommand.ts
@@ -1,6 +1,7 @@
 import * as converter from "commons/converter";
 import { UnexpectedParseError } from "commons/errors";
 import { IMetar } from "model/model";
+import { AltimeterUnit } from "model/enum";
 import { ICommand } from "../metar";
 
 export class AltimeterMercuryCommand implements ICommand {
@@ -17,8 +18,9 @@ export class AltimeterMercuryCommand implements ICommand {
 
     const mercury = +matches[1] / 100;
 
-    metar.altimeter = Math.trunc(
-      converter.convertInchesMercuryToPascal(mercury)
-    );
+    metar.altimeter = {
+      value: mercury,
+      unit: AltimeterUnit.InHg,
+    };
   }
 }

--- a/src/commons/converter.ts
+++ b/src/commons/converter.ts
@@ -94,10 +94,6 @@ export function convertTemperature(input: string): number {
   return +input;
 }
 
-export function convertInchesMercuryToPascal(input: number): number {
-  return 33.8639 * input;
-}
-
 /**
  * Converts number `.toFixed(1)` before outputting to match python implementation
  */

--- a/src/model/enum.ts
+++ b/src/model/enum.ts
@@ -410,3 +410,19 @@ export enum DepositCoverage {
   From26To50 = "5",
   From51To100 = "9",
 }
+
+export enum AltimeterUnit {
+  /**
+   * Inches of mercury (inHg)
+   *
+   * e.g. A2994 parses as 29.94 inHg
+   */
+  InHg = "inHg",
+
+  /**
+   * Hectopascals (hPa), also known as millibars
+   *
+   * e.g. Q1018 parses as 1018 millibars
+   */
+  HPa = "hPa",
+}

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -16,6 +16,7 @@ import {
   MetarType,
   DepositType,
   DepositCoverage,
+  AltimeterUnit,
 } from "model/enum";
 import { Remark } from "command/remark";
 
@@ -71,6 +72,11 @@ export function isWeatherConditionValid(weather: IWeatherCondition): boolean {
     (weather.intensity === Intensity.IN_VICINITY &&
       weather.descriptive == Descriptive.SHOWERS)
   );
+}
+
+export interface IAltimeter {
+  value: number;
+  unit: AltimeterUnit;
 }
 
 export interface ITemperature {
@@ -239,7 +245,7 @@ export interface IMetar extends IAbstractWeatherCode {
   type?: MetarType;
   temperature?: number;
   dewPoint?: number;
-  altimeter?: number;
+  altimeter?: IAltimeter;
   nosig?: true;
   runwaysInfo: RunwayInfo[];
 

--- a/tests/commons/converter.test.ts
+++ b/tests/commons/converter.test.ts
@@ -79,10 +79,6 @@ describe("convertTemperature", () => {
   });
 });
 
-test("convertInchesMercuryToPascal", () => {
-  expect(converter.convertInchesMercuryToPascal(29.92)).toBeCloseTo(1013.2, 1);
-});
-
 describe("convertTemperatureRemarks", () => {
   test("positive", () => {
     expect(converter.convertTemperatureRemarks("0", "142")).toBe(14.2);

--- a/tests/parser/parser.test.ts
+++ b/tests/parser/parser.test.ts
@@ -21,6 +21,7 @@ import {
   TurbulenceIntensity,
   IcingIntensity,
   MetarType,
+  AltimeterUnit,
 } from "model/enum";
 import { IAbstractWeatherContainer, IRunwayInfoRange } from "model/model";
 import { Direction } from "model/enum";
@@ -436,7 +437,10 @@ describe("MetarParser", () => {
     });
     expect(metar.temperature).toBe(9);
     expect(metar.dewPoint).toBe(6);
-    expect(metar.altimeter).toBe(1031);
+    expect(metar.altimeter).toStrictEqual({
+      value: 1031,
+      unit: AltimeterUnit.HPa,
+    });
     expect(metar.nosig).toBe(true);
   });
 
@@ -445,7 +449,10 @@ describe("MetarParser", () => {
       "KTTN 051853Z 04011KT 9999 VCTS SN FZFG BKN003 OVC010 M02/M02 A3006"
     );
 
-    expect(metar.altimeter).toBe(1017);
+    expect(metar.altimeter).toStrictEqual({
+      value: 30.06,
+      unit: AltimeterUnit.InHg,
+    });
     expect(metar.weatherConditions).toHaveLength(3);
   });
 


### PR DESCRIPTION
@drmrbrewer and @clioh, if you have a moment I would appreciate a quick review!

Specifically, I wasn't sure whether to specify `AltimeterUnit`'s value as `"mb"` (millibars) or `"hPa"`.

What do you prefer?