### PR TITLE
Change minimal visibility regex

### DIFF
--- a/src/command/common.ts
+++ b/src/command/common.ts
@@ -98,7 +98,7 @@ export class MainVisibilityCommand implements ICommand {
 }
 
 export class WindCommand implements ICommand {
-  #regex = /^(VRB|[0-3]\d{2})(\d{2})G?(\d{2})?(KT|MPS|KM\/H)?/;
+  #regex = /^(VRB|00|[0-3]\d{2})(\d{2})G?(\d{2})?(KT|MPS|KM\/H)?/;
 
   canParse(windString: string): boolean {
     return this.#regex.test(windString);
@@ -200,7 +200,7 @@ export class VerticalVisibilityCommand implements ICommand {
 }
 
 export class MinimalVisibilityCommand implements ICommand {
-  #regex = /^(\d{4}[a-zA-Z]{1,2})$/;
+  #regex = /^(\d{4}[NnEeSsWw]{1,2})$/;
 
   execute(
     container: IAbstractWeatherContainer,

--- a/tests/parser/parser.test.ts
+++ b/tests/parser/parser.test.ts
@@ -383,6 +383,22 @@ describe("MetarParser", () => {
     });
   });
 
+  test("wind of 0000KT should not parse as minVisibility", () => {
+    const metar = new MetarParser(en).parse(
+      "KATW 022045Z 0000KT 10SM SCT120 00/M08 A2996"
+    );
+
+    expect(metar.wind).toStrictEqual({
+      degrees: 0,
+      speed: 0,
+      unit: "KT",
+      gust: undefined,
+      direction: "N",
+    });
+
+    expect(metar.visibility?.min).toBeUndefined();
+  });
+
   test("wind variation", () => {
     const metar = new MetarParser(en).parse("LFPG 161430Z 24015G25KT 180V300");
 


### PR DESCRIPTION
Currently when the following metar is parsed `KATW 022045Z 0000KT 10SM SCT120 00/M08 A2996`, we get an error `UnexpectedParseError: container.visibility not instantiated`. This happens because wind string (`0000KT`) is matching minimal visibility regex. Suggest to update the minimal visibility to more strict, so it does not intersect with wind string.

See below the documentation for minimal visibility and possible letters in it (NESW).
![image](https://user-images.githubusercontent.com/97975824/222701088-f40a47ea-6aee-4e2d-a4d7-f677c61a109a.png)
