### PR TITLE
Fix for parse failure on TAF with station ident beginning with 'FM'

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -536,7 +536,7 @@ export class TAFParser extends AbstractParser {
     const lines = joinProbIfNeeded(
       cleanLine
         .replace(
-          /\s(?=PROB\d{2}\s(?=TEMPO|INTER)|TEMPO|INTER|BECMG|FM|PROB)/g,
+          /\s(?=PROB\d{2}\s(?=TEMPO|INTER)|TEMPO|INTER|BECMG|FM(?![A-Z]{2}\s)|PROB)/g,
           "\n"
         )
         .split(/\n/)

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -125,6 +125,16 @@ TAF
         expect(taf.minute).toBeUndefined();
       });
     });
+
+    test("parses station ident beginning with 'FM'", () => {
+      const taf = parseTAF([
+        "TAF FMMI 082300Z 0900/1006 16006KT 9999 FEW017 BKN020 PROB30",
+        "TEMPO 0908/0916 4500 RADZ",
+        "BECMG 0909/0911 10010KT",
+        "BECMG 0918/0920 16006KT"
+      ].join("\n"));
+      expect(taf.station).toBe("FMMI");
+    });
   });
 
   describe("parseTAFAsForecast", () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -127,12 +127,14 @@ TAF
     });
 
     test("parses station ident beginning with 'FM'", () => {
-      const taf = parseTAF([
-        "TAF FMMI 082300Z 0900/1006 16006KT 9999 FEW017 BKN020 PROB30",
-        "TEMPO 0908/0916 4500 RADZ",
-        "BECMG 0909/0911 10010KT",
-        "BECMG 0918/0920 16006KT"
-      ].join("\n"));
+      const taf = parseTAF(
+        [
+          "TAF FMMI 082300Z 0900/1006 16006KT 9999 FEW017 BKN020 PROB30",
+          "TEMPO 0908/0916 4500 RADZ",
+          "BECMG 0909/0911 10010KT",
+          "BECMG 0918/0920 16006KT",
+        ].join("\n")
+      );
       expect(taf.station).toBe("FMMI");
     });
   });

--- a/tests/parser/parser.test.ts
+++ b/tests/parser/parser.test.ts
@@ -2448,12 +2448,14 @@ describe("RemarkParser", () => {
   // Issue 67: previously failed in parseDeliveryTime() due to "FM" being
   // treated as an FM trend.
   test("parse TAF with station ident beginning with 'FM'", () => {
-    const taf = new TAFParser(en).parse([
-      "TAF FMMI 082300Z 0900/1006 16006KT 9999 FEW017 BKN020 PROB30",
-      "TEMPO 0908/0916 4500 RADZ",
-      "BECMG 0909/0911 10010KT",
-      "BECMG 0918/0920 16006KT"
-    ].join("\n"));
+    const taf = new TAFParser(en).parse(
+      [
+        "TAF FMMI 082300Z 0900/1006 16006KT 9999 FEW017 BKN020 PROB30",
+        "TEMPO 0908/0916 4500 RADZ",
+        "BECMG 0909/0911 10010KT",
+        "BECMG 0918/0920 16006KT",
+      ].join("\n")
+    );
 
     // Check on station
     expect(taf.station).toBe("FMMI");
@@ -2480,7 +2482,7 @@ describe("RemarkParser", () => {
     expect(taf.visibility).toEqual({
       indicator: ValueIndicator.GreaterThan,
       value: 9999,
-      unit: DistanceUnit.Meters
+      unit: DistanceUnit.Meters,
     });
 
     // Checks on clouds
@@ -2513,7 +2515,7 @@ describe("RemarkParser", () => {
     expect(tempo.validity.endHour).toBe(16);
     expect(tempo.visibility).toEqual({
       value: 4500,
-      unit: DistanceUnit.Meters
+      unit: DistanceUnit.Meters,
     });
     expect(tempo.weatherConditions).toHaveLength(1);
     expect(tempo.weatherConditions[0].phenomenons[0]).toBe("RA");
@@ -2535,7 +2537,6 @@ describe("RemarkParser", () => {
     expect(becmg1.wind?.direction).toBe("E");
     expect(becmg1.wind?.speed).toBe(10);
     expect(becmg1.wind?.unit).toBe("KT");
-
 
     // Checks on trend 3: "BECMG 0918/0920 16006KT"
     const becmg2 = taf.trends[2];

--- a/tests/parser/parser.test.ts
+++ b/tests/parser/parser.test.ts
@@ -2444,4 +2444,113 @@ describe("RemarkParser", () => {
       periodInHours: 6,
     });
   });
+
+  // Issue 67: previously failed in parseDeliveryTime() due to "FM" being
+  // treated as an FM trend.
+  test("parse TAF with station ident beginning with 'FM'", () => {
+    const taf = new TAFParser(en).parse([
+      "TAF FMMI 082300Z 0900/1006 16006KT 9999 FEW017 BKN020 PROB30",
+      "TEMPO 0908/0916 4500 RADZ",
+      "BECMG 0909/0911 10010KT",
+      "BECMG 0918/0920 16006KT"
+    ].join("\n"));
+
+    // Check on station
+    expect(taf.station).toBe("FMMI");
+
+    // Check on time delivery
+    expect(taf.day).toBe(8);
+    expect(taf.hour).toBe(23);
+    expect(taf.minute).toBe(0);
+
+    // Checks on validity
+    expect(taf.validity.startDay).toBe(9);
+    expect(taf.validity.startHour).toBe(0);
+    expect(taf.validity.endDay).toBe(10);
+    expect(taf.validity.endHour).toBe(6);
+
+    // Checks on wind
+    expect(taf.wind?.degrees).toBe(160);
+    expect(taf.wind?.direction).toBe("SSE");
+    expect(taf.wind?.speed).toBe(6);
+    expect(taf.wind?.gust).toBeUndefined();
+    expect(taf.wind?.unit).toBe("KT");
+
+    // Checks on visibility
+    expect(taf.visibility).toEqual({
+      indicator: ValueIndicator.GreaterThan,
+      value: 9999,
+      unit: DistanceUnit.Meters
+    });
+
+    // Checks on clouds
+    expect(taf.clouds).toHaveLength(2);
+    expect(taf.clouds[0].quantity).toBe(CloudQuantity.FEW);
+    expect(taf.clouds[0].height).toBe(1700);
+    expect(taf.clouds[0].type).toBeUndefined();
+    expect(taf.clouds[1].quantity).toBe(CloudQuantity.BKN);
+    expect(taf.clouds[1].height).toBe(2000);
+    expect(taf.clouds[1].type).toBeUndefined();
+
+    // Check that no weatherCondition
+    expect(taf.weatherConditions).toHaveLength(0);
+
+    // Check no temperature
+    expect(taf.maxTemperature).toBeUndefined();
+    expect(taf.minTemperature).toBeUndefined();
+
+    // Checks on trends
+    expect(taf.trends).toHaveLength(3);
+
+    // Checks on trend 1: "PROB30 TEMPO 0908/0916 4500 RADZ"
+    const tempo = taf.trends[0];
+    expect(tempo.clouds).toHaveLength(0);
+    expect(tempo.probability).toBe(30);
+    expect(tempo.type).toBe("TEMPO");
+    expect(tempo.validity.startDay).toBe(9);
+    expect(tempo.validity.startHour).toBe(8);
+    expect(tempo.validity.endDay).toBe(9);
+    expect(tempo.validity.endHour).toBe(16);
+    expect(tempo.visibility).toEqual({
+      value: 4500,
+      unit: DistanceUnit.Meters
+    });
+    expect(tempo.weatherConditions).toHaveLength(1);
+    expect(tempo.weatherConditions[0].phenomenons[0]).toBe("RA");
+    expect(tempo.weatherConditions[0].phenomenons[1]).toBe("DZ");
+    expect(tempo.wind).toBeUndefined();
+
+    // Checks on trend 2: "BECMG 0909/0911 10010KT",
+    const becmg1 = taf.trends[1];
+    expect(becmg1.clouds).toHaveLength(0);
+    expect(becmg1.probability).toBeUndefined();
+    expect(becmg1.type).toBe("BECMG");
+    expect(becmg1.validity.startDay).toBe(9);
+    expect(becmg1.validity.startHour).toBe(9);
+    expect(becmg1.validity.endDay).toBe(9);
+    expect(becmg1.validity.endHour).toBe(11);
+    expect(becmg1.visibility).toBeUndefined();
+    expect(becmg1.weatherConditions).toHaveLength(0);
+    expect(becmg1.wind?.degrees).toBe(100);
+    expect(becmg1.wind?.direction).toBe("E");
+    expect(becmg1.wind?.speed).toBe(10);
+    expect(becmg1.wind?.unit).toBe("KT");
+
+
+    // Checks on trend 3: "BECMG 0918/0920 16006KT"
+    const becmg2 = taf.trends[2];
+    expect(becmg2.clouds).toHaveLength(0);
+    expect(becmg2.probability).toBeUndefined();
+    expect(becmg2.type).toBe("BECMG");
+    expect(becmg2.validity.startDay).toBe(9);
+    expect(becmg2.validity.startHour).toBe(18);
+    expect(becmg2.validity.endDay).toBe(9);
+    expect(becmg2.validity.endHour).toBe(20);
+    expect(becmg2.visibility).toBeUndefined();
+    expect(becmg2.weatherConditions).toHaveLength(0);
+    expect(becmg2.wind?.degrees).toBe(160);
+    expect(becmg2.wind?.direction).toBe("SSE");
+    expect(becmg2.wind?.speed).toBe(6);
+    expect(becmg2.wind?.unit).toBe("KT");
+  });
 });


### PR DESCRIPTION
Addresses #67 by modifying regex in `extractLinesTokens()` to prevent station ident beginning with `FM` from being tokenized as an `FM` trend. This was previously triggering an exception in `parseDeliveryTime()`.
