### PR TITLE
Reject partial TAF

### DIFF
--- a/src/commons/errors.ts
+++ b/src/commons/errors.ts
@@ -24,6 +24,26 @@ export class InvalidWeatherStatementError extends ParseError {
 }
 
 /**
+ * Thrown when an input contains data elements that are recognized but
+ * intentionally not supported.
+ */
+export class UnsupportedWeatherStatementError extends ParseError {
+  name = "UnsupportedWeatherStatementError";
+  cause?: unknown;
+
+  constructor(public readonly reason: string, cause?: unknown) {
+    super(
+      typeof cause === "string"
+        ? `Unsupported weather string (${reason}): ${cause}`
+        : `Unsupported weather string (${reason})`
+    );
+    Object.setPrototypeOf(this, new.target.prototype);
+
+    if (typeof cause !== "string") this.cause = cause;
+  }
+}
+
+/**
  * Thrown when command marked as canParse, but couldn't parse when
  * executing (for example, an invalid CloudQuantity)
  */

--- a/src/commons/errors.ts
+++ b/src/commons/errors.ts
@@ -27,19 +27,19 @@ export class InvalidWeatherStatementError extends ParseError {
  * Thrown when an input contains data elements that are recognized but
  * intentionally not supported.
  */
-export class UnsupportedWeatherStatementError extends ParseError {
-  name = "UnsupportedWeatherStatementError";
-  cause?: unknown;
+export class PartialWeatherStatementError extends InvalidWeatherStatementError {
+  name = "PartialWeatherStatementError";
+  part: number;
+  total: number;
 
-  constructor(public readonly reason: string, cause?: unknown) {
+  constructor(partialMessage: string, part: number, total: number) {
     super(
-      typeof cause === "string"
-        ? `Unsupported weather string (${reason}): ${cause}`
-        : `Unsupported weather string (${reason})`
+      `Input is partial TAF (${partialMessage}), see: https://github.com/aeharding/metar-taf-parser/issues/68`
     );
     Object.setPrototypeOf(this, new.target.prototype);
 
-    if (typeof cause !== "string") this.cause = cause;
+    this.part = part;
+    this.total = total;
   }
 }
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -13,7 +13,7 @@ import {
   IValidity,
   IWeatherCondition,
   IValidityDated,
-  IFlags
+  IFlags,
 } from "model/model";
 import { DistanceUnit, MetarType, ValueIndicator } from "model/enum";
 import * as converter from "commons/converter";
@@ -24,12 +24,16 @@ import {
   Phenomenon,
   Descriptive,
   TimeIndicator,
-  WeatherChangeType
+  WeatherChangeType,
 } from "model/enum";
 import { CommandSupplier as MetarCommandSupplier } from "command/metar";
 import { CommandSupplier as TafCommandSupplier } from "command/taf";
 import { Locale } from "commons/i18n";
-import { CommandExecutionError, ParseError, UnsupportedWeatherStatementError } from "commons/errors";
+import {
+  CommandExecutionError,
+  ParseError,
+  UnsupportedWeatherStatementError,
+} from "commons/errors";
 
 function isStation(stationString: string): boolean {
   return stationString.length === 4;
@@ -52,7 +56,7 @@ function parseDeliveryTime(
   return {
     day,
     hour,
-    minute
+    minute,
   };
 }
 
@@ -112,7 +116,7 @@ export function parseTemperature(input: string): ITemperature {
   return {
     temperature: converter.convertTemperature(parts[0].slice(2)),
     day: +parts[1].slice(0, 2),
-    hour: +parts[1].slice(2, 4)
+    hour: +parts[1].slice(2, 4),
   };
 }
 
@@ -128,7 +132,7 @@ export function parseValidity(input: string): IValidityDated | IValidity {
     startDay: +parts[0].slice(0, 2),
     startHour: +parts[0].slice(2),
     endDay: +parts[1].slice(0, 2),
-    endHour: +parts[1].slice(2)
+    endHour: +parts[1].slice(2),
   };
 }
 
@@ -141,7 +145,7 @@ function parseFromValidity(input: string): IFMValidity {
   return {
     startDay: +input.slice(2, 4),
     startHour: +input.slice(4, 6),
-    startMinutes: +input.slice(6, 8)
+    startMinutes: +input.slice(6, 8),
   };
 }
 
@@ -162,8 +166,7 @@ export abstract class AbstractParser {
   #CAVOK = "CAVOK";
   #commonSupplier = new CommandSupplier();
 
-  constructor(protected locale: Locale) {
-  }
+  constructor(protected locale: Locale) {}
 
   parseWeatherCondition(input: string): IWeatherCondition | undefined {
     let intensity: Intensity | undefined;
@@ -190,7 +193,7 @@ export abstract class AbstractParser {
     const weatherCondition: IWeatherCondition = {
       intensity,
       descriptive,
-      phenomenons: []
+      phenomenons: [],
     };
 
     const phenomenons = Object.values(Phenomenon);
@@ -262,7 +265,7 @@ export abstract class AbstractParser {
       abstractWeatherContainer.visibility = {
         indicator: ValueIndicator.GreaterThan,
         value: 9999,
-        unit: DistanceUnit.Meters
+        unit: DistanceUnit.Meters,
       };
 
       return true;
@@ -310,7 +313,7 @@ export class MetarParser extends AbstractParser {
       trendParts[i] !== this.TEMPO &&
       trendParts[i] !== this.INTER &&
       trendParts[i] !== this.BECMG
-      ) {
+    ) {
       if (
         trendParts[i].startsWith(this.FM) ||
         trendParts[i].startsWith(this.TL) ||
@@ -319,7 +322,7 @@ export class MetarParser extends AbstractParser {
         const trendTime: IMetarTrendTime = {
           type: TimeIndicator[trendParts[i].slice(0, 2) as TimeIndicator],
           hour: +trendParts[i].slice(2, 4),
-          minute: +trendParts[i].slice(4, 6)
+          minute: +trendParts[i].slice(4, 6),
         };
 
         trend.times.push(trendTime);
@@ -362,7 +365,7 @@ export class MetarParser extends AbstractParser {
       clouds: [],
       weatherConditions: [],
       trends: [],
-      runwaysInfo: []
+      runwaysInfo: [],
     };
 
     index += 2;
@@ -387,7 +390,7 @@ export class MetarParser extends AbstractParser {
             clouds: [],
             times: [],
             remarks: [],
-            raw: ""
+            raw: "",
           };
 
           index = this.parseTrend(index, trend, metarTab);
@@ -460,19 +463,21 @@ export class TAFParser extends AbstractParser {
    * @param input original input.
    */
   throwIfUnsupported(linesTokens: string[][], input: string) {
-
     // TAFs in NOAA cycle files beginning `PART x OF y`, implying they are
     // incomplete. Being absurdly careful about identifying this to avoid any
     // false positives...
     if (linesTokens.length >= 1 && linesTokens[0].length >= 4) {
       const tokens = linesTokens[0];
       if ("PART" === tokens[0] && "OF" === tokens[2]) {
-        const indices = [tokens[1], tokens[3]]
-          .filter(token => /\d/.test(token));
+        const indices = [tokens[1], tokens[3]].filter((token) =>
+          /\d/.test(token)
+        );
         if (2 === indices.length) {
           const [part, total] = indices;
           throw new UnsupportedWeatherStatementError(
-            `Partial; "PART ${part} OF ${total}"`, input);
+            `Partial; "PART ${part} OF ${total}"`,
+            input
+          );
         }
       }
     }
@@ -506,7 +511,7 @@ export class TAFParser extends AbstractParser {
       remarks: [],
       clouds: [],
       weatherConditions: [],
-      initialRaw: lines[0].join(" ")
+      initialRaw: lines[0].join(" "),
     };
 
     for (let i = index + 1; i < lines[0].length; i++) {
@@ -526,7 +531,7 @@ export class TAFParser extends AbstractParser {
     }
 
     const minMaxTemperatureLines = [
-      lines[0].slice(index + 1) // EU countries have min/max in first line
+      lines[0].slice(index + 1), // EU countries have min/max in first line
     ];
 
     // US military bases have min/max in last line
@@ -600,7 +605,7 @@ export class TAFParser extends AbstractParser {
         ...this.makeEmptyTAFTrend(),
         type: WeatherChangeType.FM,
         validity: parseFromValidity(lineTokens[0]),
-        raw: lineTokens.join(" ")
+        raw: lineTokens.join(" "),
       };
     } else if (lineTokens[0].startsWith(this.PROB)) {
       const validity = this.findLineValidity(index, lineTokens);
@@ -610,7 +615,7 @@ export class TAFParser extends AbstractParser {
         ...this.makeEmptyTAFTrend(),
         type: WeatherChangeType.PROB,
         validity,
-        raw: lineTokens.join(" ")
+        raw: lineTokens.join(" "),
       };
 
       if (
@@ -621,7 +626,7 @@ export class TAFParser extends AbstractParser {
           ...this.makeEmptyTAFTrend(),
           type: WeatherChangeType[lineTokens[1] as WeatherChangeType],
           validity,
-          raw: lineTokens.join(" ")
+          raw: lineTokens.join(" "),
         };
         index = 2;
       }
@@ -635,7 +640,7 @@ export class TAFParser extends AbstractParser {
         ...this.makeEmptyTAFTrend(),
         type: WeatherChangeType[lineTokens[0] as WeatherChangeType],
         validity,
-        raw: lineTokens.join(" ")
+        raw: lineTokens.join(" "),
       };
     }
 
@@ -686,14 +691,13 @@ export class TAFParser extends AbstractParser {
     return {
       remarks: [],
       clouds: [],
-      weatherConditions: []
+      weatherConditions: [],
     };
   }
 }
 
 export class RemarkParser {
-  constructor(private locale: Locale) {
-  }
+  constructor(private locale: Locale) {}
 
   #supplier = new RemarkCommandSupplier(this.locale);
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -13,7 +13,7 @@ import {
   IValidity,
   IWeatherCondition,
   IValidityDated,
-  IFlags,
+  IFlags
 } from "model/model";
 import { DistanceUnit, MetarType, ValueIndicator } from "model/enum";
 import * as converter from "commons/converter";
@@ -24,12 +24,12 @@ import {
   Phenomenon,
   Descriptive,
   TimeIndicator,
-  WeatherChangeType,
+  WeatherChangeType
 } from "model/enum";
 import { CommandSupplier as MetarCommandSupplier } from "command/metar";
 import { CommandSupplier as TafCommandSupplier } from "command/taf";
 import { Locale } from "commons/i18n";
-import { CommandExecutionError } from "commons/errors";
+import { CommandExecutionError, ParseError, UnsupportedWeatherStatementError } from "commons/errors";
 
 function isStation(stationString: string): boolean {
   return stationString.length === 4;
@@ -52,7 +52,7 @@ function parseDeliveryTime(
   return {
     day,
     hour,
-    minute,
+    minute
   };
 }
 
@@ -112,7 +112,7 @@ export function parseTemperature(input: string): ITemperature {
   return {
     temperature: converter.convertTemperature(parts[0].slice(2)),
     day: +parts[1].slice(0, 2),
-    hour: +parts[1].slice(2, 4),
+    hour: +parts[1].slice(2, 4)
   };
 }
 
@@ -128,7 +128,7 @@ export function parseValidity(input: string): IValidityDated | IValidity {
     startDay: +parts[0].slice(0, 2),
     startHour: +parts[0].slice(2),
     endDay: +parts[1].slice(0, 2),
-    endHour: +parts[1].slice(2),
+    endHour: +parts[1].slice(2)
   };
 }
 
@@ -141,7 +141,7 @@ function parseFromValidity(input: string): IFMValidity {
   return {
     startDay: +input.slice(2, 4),
     startHour: +input.slice(4, 6),
-    startMinutes: +input.slice(6, 8),
+    startMinutes: +input.slice(6, 8)
   };
 }
 
@@ -162,7 +162,8 @@ export abstract class AbstractParser {
   #CAVOK = "CAVOK";
   #commonSupplier = new CommandSupplier();
 
-  constructor(protected locale: Locale) {}
+  constructor(protected locale: Locale) {
+  }
 
   parseWeatherCondition(input: string): IWeatherCondition | undefined {
     let intensity: Intensity | undefined;
@@ -189,7 +190,7 @@ export abstract class AbstractParser {
     const weatherCondition: IWeatherCondition = {
       intensity,
       descriptive,
-      phenomenons: [],
+      phenomenons: []
     };
 
     const phenomenons = Object.values(Phenomenon);
@@ -261,7 +262,7 @@ export abstract class AbstractParser {
       abstractWeatherContainer.visibility = {
         indicator: ValueIndicator.GreaterThan,
         value: 9999,
-        unit: DistanceUnit.Meters,
+        unit: DistanceUnit.Meters
       };
 
       return true;
@@ -309,7 +310,7 @@ export class MetarParser extends AbstractParser {
       trendParts[i] !== this.TEMPO &&
       trendParts[i] !== this.INTER &&
       trendParts[i] !== this.BECMG
-    ) {
+      ) {
       if (
         trendParts[i].startsWith(this.FM) ||
         trendParts[i].startsWith(this.TL) ||
@@ -318,7 +319,7 @@ export class MetarParser extends AbstractParser {
         const trendTime: IMetarTrendTime = {
           type: TimeIndicator[trendParts[i].slice(0, 2) as TimeIndicator],
           hour: +trendParts[i].slice(2, 4),
-          minute: +trendParts[i].slice(4, 6),
+          minute: +trendParts[i].slice(4, 6)
         };
 
         trend.times.push(trendTime);
@@ -361,7 +362,7 @@ export class MetarParser extends AbstractParser {
       clouds: [],
       weatherConditions: [],
       trends: [],
-      runwaysInfo: [],
+      runwaysInfo: []
     };
 
     index += 2;
@@ -386,7 +387,7 @@ export class MetarParser extends AbstractParser {
             clouds: [],
             times: [],
             remarks: [],
-            raw: "",
+            raw: ""
           };
 
           index = this.parseTrend(index, trend, metarTab);
@@ -451,6 +452,33 @@ export class TAFParser extends AbstractParser {
   }
 
   /**
+   * Check a tokenized TAF against patterns that are explicitly not supported,
+   * throwing a descriptive exception to assist anyone who might want to apply
+   * any necessary custom parsing.
+   *
+   * @param linesTokens tokenized input.
+   * @param input original input.
+   */
+  throwIfUnsupported(linesTokens: string[][], input: string) {
+
+    // TAFs in NOAA cycle files beginning `PART x OF y`, implying they are
+    // incomplete. Being absurdly careful about identifying this to avoid any
+    // false positives...
+    if (linesTokens.length >= 1 && linesTokens[0].length >= 4) {
+      const tokens = linesTokens[0];
+      if ("PART" === tokens[0] && "OF" === tokens[2]) {
+        const indices = [tokens[1], tokens[3]]
+          .filter(token => /\d/.test(token));
+        if (2 === indices.length) {
+          const [part, total] = indices;
+          throw new UnsupportedWeatherStatementError(
+            `Partial; "PART ${part} OF ${total}"`, input);
+        }
+      }
+    }
+  }
+
+  /**
    * the message to parse
    * @param input
    * @returns a TAF object
@@ -458,6 +486,7 @@ export class TAFParser extends AbstractParser {
    */
   parse(input: string): ITAF {
     const lines = this.extractLinesTokens(input);
+    this.throwIfUnsupported(lines, input);
 
     let [index, flags] = this.parseMessageStart(lines[0]);
 
@@ -477,7 +506,7 @@ export class TAFParser extends AbstractParser {
       remarks: [],
       clouds: [],
       weatherConditions: [],
-      initialRaw: lines[0].join(" "),
+      initialRaw: lines[0].join(" ")
     };
 
     for (let i = index + 1; i < lines[0].length; i++) {
@@ -497,7 +526,7 @@ export class TAFParser extends AbstractParser {
     }
 
     const minMaxTemperatureLines = [
-      lines[0].slice(index + 1), // EU countries have min/max in first line
+      lines[0].slice(index + 1) // EU countries have min/max in first line
     ];
 
     // US military bases have min/max in last line
@@ -551,6 +580,7 @@ export class TAFParser extends AbstractParser {
       }
       return ls;
     }
+
     const linesToken = lines.map(this.tokenize);
 
     return linesToken;
@@ -570,7 +600,7 @@ export class TAFParser extends AbstractParser {
         ...this.makeEmptyTAFTrend(),
         type: WeatherChangeType.FM,
         validity: parseFromValidity(lineTokens[0]),
-        raw: lineTokens.join(" "),
+        raw: lineTokens.join(" ")
       };
     } else if (lineTokens[0].startsWith(this.PROB)) {
       const validity = this.findLineValidity(index, lineTokens);
@@ -580,7 +610,7 @@ export class TAFParser extends AbstractParser {
         ...this.makeEmptyTAFTrend(),
         type: WeatherChangeType.PROB,
         validity,
-        raw: lineTokens.join(" "),
+        raw: lineTokens.join(" ")
       };
 
       if (
@@ -591,7 +621,7 @@ export class TAFParser extends AbstractParser {
           ...this.makeEmptyTAFTrend(),
           type: WeatherChangeType[lineTokens[1] as WeatherChangeType],
           validity,
-          raw: lineTokens.join(" "),
+          raw: lineTokens.join(" ")
         };
         index = 2;
       }
@@ -605,7 +635,7 @@ export class TAFParser extends AbstractParser {
         ...this.makeEmptyTAFTrend(),
         type: WeatherChangeType[lineTokens[0] as WeatherChangeType],
         validity,
-        raw: lineTokens.join(" "),
+        raw: lineTokens.join(" ")
       };
     }
 
@@ -656,13 +686,14 @@ export class TAFParser extends AbstractParser {
     return {
       remarks: [],
       clouds: [],
-      weatherConditions: [],
+      weatherConditions: []
     };
   }
 }
 
 export class RemarkParser {
-  constructor(private locale: Locale) {}
+  constructor(private locale: Locale) {
+  }
 
   #supplier = new RemarkCommandSupplier(this.locale);
 

--- a/tests/parser/parser.test.ts
+++ b/tests/parser/parser.test.ts
@@ -2471,7 +2471,7 @@ describe("RemarkParser", () => {
       }
     }
   });
-    
+
   // Issue 67: previously failed in parseDeliveryTime() due to "FM" being
   // treated as an FM trend.
   test("parse TAF with station ident beginning with 'FM'", () => {

--- a/tests/parser/parser.test.ts
+++ b/tests/parser/parser.test.ts
@@ -27,7 +27,7 @@ import { IAbstractWeatherContainer, IRunwayInfoRange } from "model/model";
 import { Direction } from "model/enum";
 import en from "locale/en";
 import { _, format } from "commons/i18n";
-import { UnsupportedWeatherStatementError } from "commons/errors";
+import { PartialWeatherStatementError } from "commons/errors";
 
 describe("RemarkParser", () => {
   (() => {
@@ -2448,7 +2448,7 @@ describe("RemarkParser", () => {
 
   test("descriptively reject TAFs beginning with 'PART x OF y'", () => {
     const input = [
-      "PART 2 OF 2 TAF SBGL 082150Z 0900/1006 09007KT CAVOK TN21/0909Z TX30/0917Z ",
+      "PART 1 OF 3 TAF SBGL 082150Z 0900/1006 09007KT CAVOK TN21/0909Z TX30/0917Z ",
       "      BECMG 0903/0905 34005KT SCT020 PROB40 0909/0912 4000 BR SCT010 BKN020 ",
       "      BECMG 0912/0914 01005KT FEW023 ",
       "      BECMG 0917/0919 23017KT SCT020 ",
@@ -2460,11 +2460,14 @@ describe("RemarkParser", () => {
       new TAFParser(en).parse(input);
       expect(true).toBe(false);
     } catch (ex) {
-      expect(ex).toBeInstanceOf(UnsupportedWeatherStatementError);
-      if (ex instanceof UnsupportedWeatherStatementError) {
-        expect(ex.reason).toContain("PART 2 OF 2");
-        expect(ex.name).toBe("UnsupportedWeatherStatementError");
-        expect(ex.message).toContain(input);
+      expect(ex).toBeInstanceOf(PartialWeatherStatementError);
+      if (ex instanceof PartialWeatherStatementError) {
+        expect(ex.part).toBe(1);
+        expect(ex.total).toBe(3);
+        expect(ex.name).toBe("PartialWeatherStatementError");
+        expect(ex.message).toContain(
+          "Input is partial TAF (PART 1 OF 3), see: https://github.com/aeharding/metar-taf-parser/issues/68"
+        );
       }
     }
   });

--- a/tests/parser/parser.test.ts
+++ b/tests/parser/parser.test.ts
@@ -2449,12 +2449,12 @@ describe("RemarkParser", () => {
 
   test("descriptively reject TAFs beginning with 'PART x OF y'", () => {
     const input = [
-      "PART 2 OF 2 TAF SBGL 082150Z 0900/1006 09007KT CAVOK TN21/0909Z TX30/0917Z " +
-      "      BECMG 0903/0905 34005KT SCT020 PROB40 0909/0912 4000 BR SCT010 BKN020 " +
-      "      BECMG 0912/0914 01005KT FEW023 " +
-      "      BECMG 0917/0919 23017KT SCT020 " +
-      "      BECMG 0921/0923 27008KT BKN025 " +
-      "      BECMG 1004/1006 5000 BR BKN010 " +
+      "PART 2 OF 2 TAF SBGL 082150Z 0900/1006 09007KT CAVOK TN21/0909Z TX30/0917Z ",
+      "      BECMG 0903/0905 34005KT SCT020 PROB40 0909/0912 4000 BR SCT010 BKN020 ",
+      "      BECMG 0912/0914 01005KT FEW023 ",
+      "      BECMG 0917/0919 23017KT SCT020 ",
+      "      BECMG 0921/0923 27008KT BKN025 ",
+      "      BECMG 1004/1006 5000 BR BKN010 ",
       "      RMK PHP"
     ].join("\n");
     try {

--- a/tests/parser/parser.test.ts
+++ b/tests/parser/parser.test.ts
@@ -5,7 +5,7 @@ import {
   parseTemperature,
   parseValidity,
   RemarkParser,
-  TAFParser,
+  TAFParser
 } from "parser/parser";
 import {
   CloudQuantity,
@@ -21,12 +21,13 @@ import {
   TurbulenceIntensity,
   IcingIntensity,
   MetarType,
-  AltimeterUnit,
+  AltimeterUnit
 } from "model/enum";
 import { IAbstractWeatherContainer, IRunwayInfoRange } from "model/model";
 import { Direction } from "model/enum";
 import en from "locale/en";
 import { _, format } from "commons/i18n";
+import { UnsupportedWeatherStatementError } from "commons/errors";
 
 describe("RemarkParser", () => {
   (() => {
@@ -38,23 +39,24 @@ describe("RemarkParser", () => {
       expect(remarks).toStrictEqual<Remark[]>([
         {
           type: RemarkType.Unknown,
-          raw: "Token",
+          raw: "Token"
         },
         {
           type: RemarkType.AO1,
           description: en.Remark.AO1,
-          raw: "AO1",
+          raw: "AO1"
         },
         {
           type: RemarkType.Unknown,
-          raw: "End of remark",
-        },
+          raw: "End of remark"
+        }
       ]);
     });
   })();
 });
 
-class StubParser extends AbstractParser {}
+class StubParser extends AbstractParser {
+}
 
 describe("parseWeatherCondition", () => {
   (() => {
@@ -91,7 +93,7 @@ describe("parseWeatherCondition", () => {
       expect(weatherCondition?.descriptive).toBe(Descriptive.SHOWERS);
       expect(weatherCondition?.phenomenons).toEqual([
         Phenomenon.RAIN,
-        Phenomenon.HAIL,
+        Phenomenon.HAIL
       ]);
     });
   })();
@@ -106,7 +108,7 @@ describe("parseWeatherCondition", () => {
       expect(weatherCondition?.descriptive).toBeUndefined();
       expect(weatherCondition?.phenomenons).toEqual([
         Phenomenon.DRIZZLE,
-        Phenomenon.MIST,
+        Phenomenon.MIST
       ]);
     });
   })();
@@ -169,7 +171,7 @@ describe("parseWeatherCondition", () => {
       "TSB40",
       "SLP176",
       "P0002",
-      "T10171017",
+      "T10171017"
     ];
 
     const res = new StubParser(en).tokenize(code);
@@ -188,7 +190,7 @@ describe("parseWeatherCondition", () => {
     ["SCT026CB", true],
     ["ZZZ026CV", false],
     ["+SHGSRA", true],
-    ["+VFDR", false],
+    ["+VFDR", false]
   ];
 
   values.forEach(([input, expected]) => {
@@ -199,7 +201,7 @@ describe("parseWeatherCondition", () => {
             weatherConditions: [],
             visibility: {},
             wind: {},
-            clouds: [],
+            clouds: []
           } as unknown as IAbstractWeatherContainer,
           input
         )
@@ -226,7 +228,7 @@ describe("MetarParser", () => {
     expect(metar.visibility).toBeDefined();
     expect(metar.visibility).toEqual({
       value: 350,
-      unit: DistanceUnit.Meters,
+      unit: DistanceUnit.Meters
     });
     expect(metar.runwaysInfo).toHaveLength(8);
     expect(metar.runwaysInfo[0].name).toBe("27L");
@@ -278,7 +280,7 @@ describe("MetarParser", () => {
     expect(trend.times).toHaveLength(0);
     expect(trend.visibility).toEqual({
       value: 3000,
-      unit: DistanceUnit.Meters,
+      unit: DistanceUnit.Meters
     });
     expect(trend.weatherConditions).toHaveLength(1);
     expect(trend.raw).toBe("TEMPO 26015G25KT 3000 TSRA SCT025CB BKN050");
@@ -357,7 +359,7 @@ describe("MetarParser", () => {
     expect(metar.visibility).toStrictEqual({
       indicator: ValueIndicator.GreaterThan,
       value: 9999,
-      unit: DistanceUnit.Meters,
+      unit: DistanceUnit.Meters
     });
     expect(trend.raw).toBe("TEMPO FM1700 TL1830 SHRA");
   });
@@ -378,8 +380,8 @@ describe("MetarParser", () => {
       unit: DistanceUnit.Meters,
       min: {
         value: 1100,
-        direction: "w",
-      },
+        direction: "w"
+      }
     });
   });
 
@@ -393,7 +395,7 @@ describe("MetarParser", () => {
       speed: 0,
       unit: "KT",
       gust: undefined,
-      direction: "N",
+      direction: "N"
     });
 
     expect(metar.visibility?.min).toBeUndefined();
@@ -421,7 +423,7 @@ describe("MetarParser", () => {
     expect(metar.wind?.degrees).toBe(280);
     expect(metar.visibility).toStrictEqual({
       value: 350,
-      unit: DistanceUnit.Meters,
+      unit: DistanceUnit.Meters
     });
     expect(metar.verticalVisibility).toBe(200);
     expect(metar.weatherConditions[0].phenomenons[0]).toBe(Phenomenon.FOG);
@@ -436,7 +438,7 @@ describe("MetarParser", () => {
       indicator: ValueIndicator.GreaterThan,
       value: 9999,
       unit: DistanceUnit.Meters,
-      ndv: true,
+      ndv: true
     });
   });
 
@@ -449,13 +451,13 @@ describe("MetarParser", () => {
     expect(metar.visibility).toStrictEqual({
       indicator: ValueIndicator.GreaterThan,
       value: 9999,
-      unit: DistanceUnit.Meters,
+      unit: DistanceUnit.Meters
     });
     expect(metar.temperature).toBe(9);
     expect(metar.dewPoint).toBe(6);
     expect(metar.altimeter).toStrictEqual({
       value: 1031,
-      unit: AltimeterUnit.HPa,
+      unit: AltimeterUnit.HPa
     });
     expect(metar.nosig).toBe(true);
   });
@@ -467,7 +469,7 @@ describe("MetarParser", () => {
 
     expect(metar.altimeter).toStrictEqual({
       value: 30.06,
-      unit: AltimeterUnit.InHg,
+      unit: AltimeterUnit.InHg
     });
     expect(metar.weatherConditions).toHaveLength(3);
   });
@@ -544,7 +546,7 @@ describe("MetarParser", () => {
     expect(metar.visibility).toEqual({
       indicator: ValueIndicator.LessThan,
       value: 0.25,
-      unit: DistanceUnit.StatuteMiles,
+      unit: DistanceUnit.StatuteMiles
     });
   });
 
@@ -554,7 +556,7 @@ describe("MetarParser", () => {
     expect(metar.visibility).toEqual({
       indicator: ValueIndicator.GreaterThan,
       value: 6,
-      unit: DistanceUnit.StatuteMiles,
+      unit: DistanceUnit.StatuteMiles
     });
   });
 
@@ -563,7 +565,7 @@ describe("MetarParser", () => {
 
     expect(metar.visibility).toEqual({
       value: 3.25,
-      unit: DistanceUnit.StatuteMiles,
+      unit: DistanceUnit.StatuteMiles
     });
   });
 
@@ -573,7 +575,7 @@ describe("MetarParser", () => {
     expect(metar.visibility).toEqual({
       indicator: ValueIndicator.GreaterThan,
       value: 1.5,
-      unit: DistanceUnit.StatuteMiles,
+      unit: DistanceUnit.StatuteMiles
     });
   });
 
@@ -705,7 +707,7 @@ describe("TAFParser", () => {
 
     expect(taf.visibility).toEqual({
       value: 6000,
-      unit: DistanceUnit.Meters,
+      unit: DistanceUnit.Meters
     });
 
     expect(taf.clouds).toHaveLength(1);
@@ -731,7 +733,7 @@ describe("TAFParser", () => {
     expect(trend0.validity.endHour).toBe(9);
     expect(trend0.visibility).toEqual({
       value: 3000,
-      unit: DistanceUnit.Meters,
+      unit: DistanceUnit.Meters
     });
     expect(trend0.weatherConditions).toHaveLength(1);
     expect(trend0.weatherConditions[0].intensity).toBeUndefined();
@@ -752,7 +754,7 @@ describe("TAFParser", () => {
     expect(trend1.wind).toBeUndefined();
     expect(trend1.visibility).toEqual({
       value: 400,
-      unit: DistanceUnit.Meters,
+      unit: DistanceUnit.Meters
     });
     expect(trend1.weatherConditions).toHaveLength(1);
     expect(trend1.weatherConditions[0].intensity).toBeUndefined();
@@ -773,7 +775,7 @@ describe("TAFParser", () => {
     expect(trend2.validity.endHour).toBe(16);
     expect(trend2.visibility).toEqual({
       value: 4000,
-      unit: DistanceUnit.Meters,
+      unit: DistanceUnit.Meters
     });
     expect(trend2.weatherConditions).toHaveLength(1);
     expect(trend2.weatherConditions[0].intensity).toBe(Intensity.LIGHT);
@@ -806,7 +808,7 @@ describe("TAFParser", () => {
     expect(trend4.validity.endHour).toBe(8);
     expect(trend4.visibility).toEqual({
       value: 3000,
-      unit: DistanceUnit.Meters,
+      unit: DistanceUnit.Meters
     });
     expect(trend4.weatherConditions).toHaveLength(1);
     expect(trend4.weatherConditions[0].intensity).toBeUndefined();
@@ -827,7 +829,7 @@ describe("TAFParser", () => {
     expect(trend5.validity.endHour).toBe(7);
     expect(trend5.visibility).toEqual({
       value: 400,
-      unit: DistanceUnit.Meters,
+      unit: DistanceUnit.Meters
     });
     expect(trend5.weatherConditions).toHaveLength(1);
     expect(trend5.weatherConditions[0].intensity).toBeUndefined();
@@ -870,7 +872,7 @@ describe("TAFParser", () => {
     expect(taf.visibility).toEqual({
       indicator: ValueIndicator.GreaterThan,
       value: 9999,
-      unit: DistanceUnit.Meters,
+      unit: DistanceUnit.Meters
     });
 
     // Checks on clouds
@@ -913,7 +915,7 @@ describe("TAFParser", () => {
     expect(becmg0.validity.endHour).toBe(4);
     expect(becmg0.visibility).toEqual({
       value: 4000,
-      unit: DistanceUnit.Meters,
+      unit: DistanceUnit.Meters
     });
     expect(becmg0.weatherConditions[0].intensity).toBeUndefined();
     expect(becmg0.weatherConditions[0].descriptive).toBe(Descriptive.SHALLOW);
@@ -929,7 +931,7 @@ describe("TAFParser", () => {
     expect(prob0.validity.endHour).toBe(7);
     expect(prob0.visibility).toEqual({
       value: 1500,
-      unit: DistanceUnit.Meters,
+      unit: DistanceUnit.Meters
     });
     expect(prob0.weatherConditions[0].intensity).toBeUndefined();
     expect(prob0.weatherConditions[0].descriptive).toBe(Descriptive.PATCHES);
@@ -949,7 +951,7 @@ describe("TAFParser", () => {
     expect(becmg1.visibility).toEqual({
       indicator: ValueIndicator.GreaterThan,
       value: 9999,
-      unit: DistanceUnit.Meters,
+      unit: DistanceUnit.Meters
     });
     expect(becmg1.weatherConditions).toHaveLength(0);
     expect(becmg1.clouds).toHaveLength(1);
@@ -998,7 +1000,7 @@ describe("TAFParser", () => {
     expect(taf.visibility).toEqual({
       indicator: ValueIndicator.GreaterThan,
       value: 9999,
-      unit: DistanceUnit.Meters,
+      unit: DistanceUnit.Meters
     });
 
     // Checks on clouds
@@ -1032,7 +1034,7 @@ describe("TAFParser", () => {
     expect(becmg1.visibility).toEqual({
       indicator: ValueIndicator.GreaterThan,
       value: 9999,
-      unit: DistanceUnit.Meters,
+      unit: DistanceUnit.Meters
     });
     expect(becmg1.wind?.degrees).toBe(100);
     expect(becmg1.wind?.speed).toBe(10);
@@ -1053,7 +1055,7 @@ describe("TAFParser", () => {
     expect(becmg2.visibility).toEqual({
       indicator: ValueIndicator.GreaterThan,
       value: 9999,
-      unit: DistanceUnit.Meters,
+      unit: DistanceUnit.Meters
     });
     expect(becmg2.wind?.degrees).toBeUndefined();
     expect(becmg2.wind?.speed).toBe(6);
@@ -1110,22 +1112,22 @@ describe("TAFParser", () => {
     // THEN the visibility of the main event is 6 SM
     expect(taf.visibility).toEqual({
       value: 6,
-      unit: DistanceUnit.StatuteMiles,
+      unit: DistanceUnit.StatuteMiles
     });
     // THEN the visibility of the first tempo is 11/2 SM
     expect(taf.trends[0].visibility).toEqual({
       value: 5.5,
-      unit: DistanceUnit.StatuteMiles,
+      unit: DistanceUnit.StatuteMiles
     });
     // THEN the visibility of the second tempo is 3/4 SM
     expect(taf.trends[2].visibility).toEqual({
       value: 0.75,
-      unit: DistanceUnit.StatuteMiles,
+      unit: DistanceUnit.StatuteMiles
     });
     // Then the visibility of the FROM part is 2SN
     expect(taf.trends[1].visibility).toEqual({
       value: 2,
-      unit: DistanceUnit.StatuteMiles,
+      unit: DistanceUnit.StatuteMiles
     });
     expect(taf.amendment).toBe(true);
   });
@@ -1384,7 +1386,7 @@ describe("TAFParser", () => {
     );
     expect(parsed.trends[2].weatherConditions[0].phenomenons).toEqual([
       "DZ",
-      "BR",
+      "BR"
     ]);
     expect(parsed.trends[2].weatherConditions[0].descriptive).toBeUndefined();
   });
@@ -1578,7 +1580,7 @@ describe("RemarkParser", () => {
     expect(remarks[1]).toEqual<Remark>({
       type: RemarkType.AO1,
       description: _("Remark.AO1", en),
-      raw: "AO1",
+      raw: "AO1"
     });
   });
 
@@ -1589,7 +1591,7 @@ describe("RemarkParser", () => {
     expect(remarks[1]).toEqual<Remark>({
       type: RemarkType.AO2,
       description: _("Remark.AO2", en),
-      raw: "AO2",
+      raw: "AO2"
     });
   });
 
@@ -1600,7 +1602,7 @@ describe("RemarkParser", () => {
     expect(remarks[0]).toEqual<Remark>({
       type: RemarkType.AO1,
       description: _("Remark.AO1", en),
-      raw: "AO1",
+      raw: "AO1"
     });
     expect(remarks[1]).toEqual<Remark>({
       type: RemarkType.WindPeak,
@@ -1608,7 +1610,7 @@ describe("RemarkParser", () => {
       raw: "PK WND 28045/15",
       speed: 45,
       degrees: 280,
-      startMinute: 15,
+      startMinute: 15
     });
   });
 
@@ -1619,7 +1621,7 @@ describe("RemarkParser", () => {
     expect(remarks[0]).toEqual<Remark>({
       type: RemarkType.AO1,
       description: _("Remark.AO1", en),
-      raw: "AO1",
+      raw: "AO1"
     });
     expect(remarks[1]).toEqual<Remark>({
       type: RemarkType.WindPeak,
@@ -1628,7 +1630,7 @@ describe("RemarkParser", () => {
       speed: 45,
       degrees: 280,
       startHour: 15,
-      startMinute: 15,
+      startMinute: 15
     });
   });
 
@@ -1640,7 +1642,7 @@ describe("RemarkParser", () => {
       type: RemarkType.WindShift,
       description: format(_("Remark.WindShift.0", en), "", 30),
       raw: "WSHFT 30",
-      startMinute: 30,
+      startMinute: 30
     });
   });
 
@@ -1653,7 +1655,7 @@ describe("RemarkParser", () => {
       description: format(_("Remark.WindShift.0", en), 15, 30),
       raw: "WSHFT 1530",
       startHour: 15,
-      startMinute: 30,
+      startMinute: 30
     });
   });
 
@@ -1666,7 +1668,7 @@ describe("RemarkParser", () => {
       description: format(_("Remark.WindShift.FROPA", en), 15, 30),
       raw: "WSHFT 1530 FROPA",
       startHour: 15,
-      startMinute: 30,
+      startMinute: 30
     });
   });
 
@@ -1678,7 +1680,7 @@ describe("RemarkParser", () => {
       type: RemarkType.WindShiftFropa,
       description: format(_("Remark.WindShift.FROPA", en), "", 30),
       raw: "WSHFT 30 FROPA",
-      startMinute: 30,
+      startMinute: 30
     });
   });
 
@@ -1690,7 +1692,7 @@ describe("RemarkParser", () => {
       type: RemarkType.TowerVisibility,
       description: format(_("Remark.Tower.Visibility", en), "16 1/2"),
       raw: "TWR VIS 16 1/2",
-      distance: 16.5,
+      distance: 16.5
     });
   });
 
@@ -1702,7 +1704,7 @@ describe("RemarkParser", () => {
       type: RemarkType.SurfaceVisibility,
       description: format(_("Remark.Surface.Visibility", en), "16 1/2"),
       raw: "SFC VIS 16 1/2",
-      distance: 16.5,
+      distance: 16.5
     });
   });
 
@@ -1719,7 +1721,7 @@ describe("RemarkParser", () => {
       ),
       raw: "VIS 1/2V2",
       minVisibility: 0.5,
-      maxVisibility: 2,
+      maxVisibility: 2
     });
   });
 
@@ -1736,7 +1738,7 @@ describe("RemarkParser", () => {
       ),
       raw: "VIS NE 2 1/2",
       distance: 2.5,
-      direction: Direction.NE,
+      direction: Direction.NE
     });
   });
 
@@ -1753,7 +1755,7 @@ describe("RemarkParser", () => {
       ),
       raw: "VIS 2 1/2 RWY11",
       distance: 2.5,
-      location: "RWY11",
+      location: "RWY11"
     });
   });
 
@@ -1775,7 +1777,7 @@ describe("RemarkParser", () => {
       tornadicType: "TORNADO",
       startMinute: 13,
       distance: 6,
-      direction: Direction.NE,
+      direction: Direction.NE
     });
   });
 
@@ -1798,7 +1800,7 @@ describe("RemarkParser", () => {
       startHour: 15,
       startMinute: 13,
       distance: 6,
-      direction: Direction.NE,
+      direction: Direction.NE
     });
   });
 
@@ -1827,7 +1829,7 @@ describe("RemarkParser", () => {
       endHour: 16,
       endMinute: 30,
       distance: 6,
-      direction: Direction.NE,
+      direction: Direction.NE
     });
   });
 
@@ -1849,7 +1851,7 @@ describe("RemarkParser", () => {
       tornadicType: "WATERSPOUT",
       endMinute: 16,
       distance: 12,
-      direction: Direction.NE,
+      direction: Direction.NE
     });
   });
 
@@ -1872,7 +1874,7 @@ describe("RemarkParser", () => {
       endHour: 15,
       endMinute: 16,
       distance: 12,
-      direction: Direction.NE,
+      direction: Direction.NE
     });
   });
 
@@ -1894,7 +1896,7 @@ describe("RemarkParser", () => {
       raw: "RAB05E30",
       phenomenon: Phenomenon.RAIN,
       startMin: 5,
-      endMin: 30,
+      endMin: 30
     });
     expect(remarks[2]).toEqual<Remark>({
       type: RemarkType.PrecipitationBegEnd,
@@ -1912,7 +1914,7 @@ describe("RemarkParser", () => {
       startHour: 15,
       startMin: 20,
       endHour: 16,
-      endMin: 55,
+      endMin: 55
     });
   });
 
@@ -1935,7 +1937,7 @@ describe("RemarkParser", () => {
       descriptive: Descriptive.SHOWERS,
       phenomenon: Phenomenon.RAIN,
       startMin: 5,
-      endMin: 30,
+      endMin: 30
     });
     expect(remarks[2]).toEqual<Remark>({
       type: RemarkType.PrecipitationBegEnd,
@@ -1952,7 +1954,7 @@ describe("RemarkParser", () => {
       descriptive: Descriptive.SHOWERS,
       phenomenon: Phenomenon.SNOW,
       startMin: 20,
-      endMin: 55,
+      endMin: 55
     });
   });
 
@@ -1972,7 +1974,7 @@ describe("RemarkParser", () => {
       raw: "SHRAB05",
       descriptive: Descriptive.SHOWERS,
       phenomenon: Phenomenon.RAIN,
-      startMin: 5,
+      startMin: 5
     });
     expect(remarks[2]).toEqual<Remark>({
       type: RemarkType.PrecipitationBeg,
@@ -1987,7 +1989,7 @@ describe("RemarkParser", () => {
       descriptive: Descriptive.SHOWERS,
       phenomenon: Phenomenon.SNOW,
       startHour: 2,
-      startMin: 20,
+      startMin: 20
     });
   });
 
@@ -2009,7 +2011,7 @@ describe("RemarkParser", () => {
       raw: "SHRAE05",
       descriptive: Descriptive.SHOWERS,
       phenomenon: Phenomenon.RAIN,
-      endMin: 5,
+      endMin: 5
     });
     expect(remarks[2]).toEqual<Remark>({
       type: RemarkType.PrecipitationEnd,
@@ -2024,7 +2026,7 @@ describe("RemarkParser", () => {
       descriptive: Descriptive.SHOWERS,
       phenomenon: Phenomenon.SNOW,
       endHour: 1,
-      endMin: 20,
+      endMin: 20
     });
   });
 
@@ -2047,7 +2049,7 @@ describe("RemarkParser", () => {
       phenomenon: Phenomenon.THUNDERSTORM,
       startHour: 1,
       startMin: 59,
-      endMin: 30,
+      endMin: 30
     });
   });
 
@@ -2062,7 +2064,7 @@ describe("RemarkParser", () => {
         _("Converter.SE", en)
       ),
       raw: "TS SE",
-      location: Direction.SE,
+      location: Direction.SE
     });
   });
 
@@ -2079,7 +2081,7 @@ describe("RemarkParser", () => {
       ),
       raw: "TS SE MOV NE",
       location: Direction.SE,
-      moving: Direction.NE,
+      moving: Direction.NE
     });
   });
 
@@ -2091,7 +2093,7 @@ describe("RemarkParser", () => {
       type: RemarkType.HailSize,
       description: format(_("Remark.Hail.0", en), "1 3/4"),
       raw: "GR 1 3/4",
-      size: 1.75,
+      size: 1.75
     });
   });
 
@@ -2103,7 +2105,7 @@ describe("RemarkParser", () => {
       type: RemarkType.SmallHailSize,
       description: format(_("Remark.Hail.LesserThan", en), "1/4"),
       raw: "GR LESS THAN 1/4",
-      size: 0.25,
+      size: 0.25
     });
   });
 
@@ -2115,7 +2117,7 @@ describe("RemarkParser", () => {
       type: RemarkType.SnowPellets,
       description: format(_("Remark.Snow.Pellets", en), _("Remark.MOD", en)),
       raw: "GS MOD",
-      amount: "MOD",
+      amount: "MOD"
     });
   });
 
@@ -2130,7 +2132,7 @@ describe("RemarkParser", () => {
         _("Converter.SW", en)
       ),
       raw: "VIRGA SW",
-      direction: Direction.SW,
+      direction: Direction.SW
     });
   });
 
@@ -2141,7 +2143,7 @@ describe("RemarkParser", () => {
     expect(remarks[1]).toEqual<Remark>({
       type: RemarkType.VIRGA,
       description: format(_("Remark.VIRGA", en)),
-      raw: "VIRGA",
+      raw: "VIRGA"
     });
   });
 
@@ -2154,7 +2156,7 @@ describe("RemarkParser", () => {
       description: format(_("Remark.Ceiling.Height", en), 500, 1000),
       raw: "CIG 005V010",
       min: 500,
-      max: 1000,
+      max: 1000
     });
   });
 
@@ -2173,7 +2175,7 @@ describe("RemarkParser", () => {
       raw: "FU BKN020",
       quantity: CloudQuantity.BKN,
       height: 2000,
-      phenomenon: Phenomenon.SMOKE,
+      phenomenon: Phenomenon.SMOKE
     });
   });
 
@@ -2188,7 +2190,7 @@ describe("RemarkParser", () => {
         _("CloudQuantity.OVC", en)
       ),
       raw: "BKN V OVC",
-      cloudQuantityRange: [CloudQuantity.BKN, CloudQuantity.OVC],
+      cloudQuantityRange: [CloudQuantity.BKN, CloudQuantity.OVC]
     });
   });
 
@@ -2205,7 +2207,7 @@ describe("RemarkParser", () => {
       ),
       raw: "BKN014 V OVC",
       cloudQuantityRange: [CloudQuantity.BKN, CloudQuantity.OVC],
-      height: 1400,
+      height: 1400
     });
   });
 
@@ -2221,7 +2223,7 @@ describe("RemarkParser", () => {
       ),
       raw: "CIG 002 RWY11",
       height: 200,
-      location: "RWY11",
+      location: "RWY11"
     });
   });
 
@@ -2232,7 +2234,7 @@ describe("RemarkParser", () => {
       type: RemarkType.SeaLevelPressure,
       description: format(_("Remark.Sea.Level.Pressure", en), "1013.4"),
       raw: "SLP134",
-      pressure: 1013.4,
+      pressure: 1013.4
     });
   });
 
@@ -2243,7 +2245,7 @@ describe("RemarkParser", () => {
       type: RemarkType.SeaLevelPressure,
       description: format(_("Remark.Sea.Level.Pressure", en), "998.2"),
       raw: "SLP982",
-      pressure: 998.2,
+      pressure: 998.2
     });
   });
 
@@ -2255,7 +2257,7 @@ describe("RemarkParser", () => {
       description: format(_("Remark.Snow.Increasing.Rapidly", en), 2, 10),
       raw: "SNINCR 2/10",
       inchesLastHour: 2,
-      totalDepth: 10,
+      totalDepth: 10
     });
   });
 
@@ -2268,7 +2270,7 @@ describe("RemarkParser", () => {
       type: RemarkType.SeaLevelPressure,
       description: format(_("Remark.Sea.Level.Pressure", en), "1009.1"),
       raw: "SLP091",
-      pressure: 1009.1,
+      pressure: 1009.1
     });
   });
 
@@ -2281,7 +2283,7 @@ describe("RemarkParser", () => {
         "24-hour maximum temperature of 10.0°C and 24-hour minimum temperature of -1.5°C",
       raw: "401001015",
       max: 10,
-      min: -1.5,
+      min: -1.5
     });
   });
 
@@ -2292,7 +2294,7 @@ describe("RemarkParser", () => {
       type: RemarkType.HourlyMaximumTemperature,
       description: "6-hourly maximum temperature of -2.1°C",
       raw: "11021",
-      max: -2.1,
+      max: -2.1
     });
   });
 
@@ -2303,7 +2305,7 @@ describe("RemarkParser", () => {
       type: RemarkType.HourlyMaximumTemperature,
       description: "6-hourly maximum temperature of 14.2°C",
       raw: "10142",
-      max: 14.2,
+      max: 14.2
     });
   });
 
@@ -2314,7 +2316,7 @@ describe("RemarkParser", () => {
       type: RemarkType.HourlyMinimumTemperature,
       description: "6-hourly minimum temperature of -0.1°C",
       raw: "21001",
-      min: -0.1,
+      min: -0.1
     });
   });
 
@@ -2325,7 +2327,7 @@ describe("RemarkParser", () => {
       type: RemarkType.HourlyMinimumTemperature,
       description: "6-hourly minimum temperature of 1.2°C",
       raw: "20012",
-      min: 1.2,
+      min: 1.2
     });
   });
 
@@ -2338,7 +2340,7 @@ describe("RemarkParser", () => {
         "steady or unsteady increase of 3.2 hectopascals in the past 3 hours",
       raw: "52032",
       code: 2,
-      pressureChange: 3.2,
+      pressureChange: 3.2
     });
   });
 
@@ -2349,7 +2351,7 @@ describe("RemarkParser", () => {
       type: RemarkType.PrecipitationAmount24Hour,
       description: "1.25 inches of precipitation fell in the last 24 hours",
       raw: "70125",
-      amount: 1.25,
+      amount: 1.25
     });
   });
 
@@ -2360,7 +2362,7 @@ describe("RemarkParser", () => {
       type: RemarkType.SnowDepth,
       description: "snow depth of 21 inches",
       raw: "4/021",
-      depth: 21,
+      depth: 21
     });
   });
 
@@ -2371,7 +2373,7 @@ describe("RemarkParser", () => {
       type: RemarkType.SunshineDuration,
       description: "96 minutes of sunshine",
       raw: "98096",
-      duration: 96,
+      duration: 96
     });
   });
 
@@ -2382,7 +2384,7 @@ describe("RemarkParser", () => {
       type: RemarkType.WaterEquivalentSnow,
       description: "water equivalent of 3.6 inches of snow",
       raw: "933036",
-      amount: 3.6,
+      amount: 3.6
     });
   });
 
@@ -2394,7 +2396,7 @@ describe("RemarkParser", () => {
       description: "4/100 of an inch of ice accretion in the past 1 hour(s)",
       raw: "l1004",
       amount: 0.04,
-      periodInHours: 1,
+      periodInHours: 1
     });
   });
 
@@ -2405,7 +2407,7 @@ describe("RemarkParser", () => {
       type: RemarkType.HourlyTemperatureDewPoint,
       description: "hourly temperature of 2.6°C",
       raw: "T0026",
-      temperature: 2.6,
+      temperature: 2.6
     });
   });
 
@@ -2417,7 +2419,7 @@ describe("RemarkParser", () => {
       description: "hourly temperature of 2.6°C and dew point of -1.5°C",
       raw: "T00261015",
       temperature: 2.6,
-      dewPoint: -1.5,
+      dewPoint: -1.5
     });
   });
 
@@ -2429,7 +2431,7 @@ describe("RemarkParser", () => {
       description: "2.17 inches of precipitation fell in the last 3 hours",
       raw: "30217",
       amount: 2.17,
-      periodInHours: 3,
+      periodInHours: 3
     });
   });
 
@@ -2441,7 +2443,30 @@ describe("RemarkParser", () => {
       description: "2.17 inches of precipitation fell in the last 6 hours",
       raw: "60217",
       amount: 2.17,
-      periodInHours: 6,
+      periodInHours: 6
     });
+  });
+
+  test("descriptively reject TAFs beginning with 'PART x OF y'", () => {
+    const input = [
+      "PART 2 OF 2 TAF SBGL 082150Z 0900/1006 09007KT CAVOK TN21/0909Z TX30/0917Z " +
+      "      BECMG 0903/0905 34005KT SCT020 PROB40 0909/0912 4000 BR SCT010 BKN020 " +
+      "      BECMG 0912/0914 01005KT FEW023 " +
+      "      BECMG 0917/0919 23017KT SCT020 " +
+      "      BECMG 0921/0923 27008KT BKN025 " +
+      "      BECMG 1004/1006 5000 BR BKN010 " +
+      "      RMK PHP"
+    ].join("\n");
+    try {
+      new TAFParser(en).parse(input);
+      expect(true).toBe(false);
+    } catch (ex) {
+      expect(ex).toBeInstanceOf(UnsupportedWeatherStatementError);
+      if (ex instanceof UnsupportedWeatherStatementError) {
+        expect(ex.reason).toContain("PART 2 OF 2");
+        expect(ex.name).toBe("UnsupportedWeatherStatementError");
+        expect(ex.message).toContain(input);
+      }
+    }
   });
 });

--- a/tests/parser/parser.test.ts
+++ b/tests/parser/parser.test.ts
@@ -5,7 +5,7 @@ import {
   parseTemperature,
   parseValidity,
   RemarkParser,
-  TAFParser
+  TAFParser,
 } from "parser/parser";
 import {
   CloudQuantity,
@@ -21,7 +21,7 @@ import {
   TurbulenceIntensity,
   IcingIntensity,
   MetarType,
-  AltimeterUnit
+  AltimeterUnit,
 } from "model/enum";
 import { IAbstractWeatherContainer, IRunwayInfoRange } from "model/model";
 import { Direction } from "model/enum";
@@ -39,24 +39,23 @@ describe("RemarkParser", () => {
       expect(remarks).toStrictEqual<Remark[]>([
         {
           type: RemarkType.Unknown,
-          raw: "Token"
+          raw: "Token",
         },
         {
           type: RemarkType.AO1,
           description: en.Remark.AO1,
-          raw: "AO1"
+          raw: "AO1",
         },
         {
           type: RemarkType.Unknown,
-          raw: "End of remark"
-        }
+          raw: "End of remark",
+        },
       ]);
     });
   })();
 });
 
-class StubParser extends AbstractParser {
-}
+class StubParser extends AbstractParser {}
 
 describe("parseWeatherCondition", () => {
   (() => {
@@ -93,7 +92,7 @@ describe("parseWeatherCondition", () => {
       expect(weatherCondition?.descriptive).toBe(Descriptive.SHOWERS);
       expect(weatherCondition?.phenomenons).toEqual([
         Phenomenon.RAIN,
-        Phenomenon.HAIL
+        Phenomenon.HAIL,
       ]);
     });
   })();
@@ -108,7 +107,7 @@ describe("parseWeatherCondition", () => {
       expect(weatherCondition?.descriptive).toBeUndefined();
       expect(weatherCondition?.phenomenons).toEqual([
         Phenomenon.DRIZZLE,
-        Phenomenon.MIST
+        Phenomenon.MIST,
       ]);
     });
   })();
@@ -171,7 +170,7 @@ describe("parseWeatherCondition", () => {
       "TSB40",
       "SLP176",
       "P0002",
-      "T10171017"
+      "T10171017",
     ];
 
     const res = new StubParser(en).tokenize(code);
@@ -190,7 +189,7 @@ describe("parseWeatherCondition", () => {
     ["SCT026CB", true],
     ["ZZZ026CV", false],
     ["+SHGSRA", true],
-    ["+VFDR", false]
+    ["+VFDR", false],
   ];
 
   values.forEach(([input, expected]) => {
@@ -201,7 +200,7 @@ describe("parseWeatherCondition", () => {
             weatherConditions: [],
             visibility: {},
             wind: {},
-            clouds: []
+            clouds: [],
           } as unknown as IAbstractWeatherContainer,
           input
         )
@@ -228,7 +227,7 @@ describe("MetarParser", () => {
     expect(metar.visibility).toBeDefined();
     expect(metar.visibility).toEqual({
       value: 350,
-      unit: DistanceUnit.Meters
+      unit: DistanceUnit.Meters,
     });
     expect(metar.runwaysInfo).toHaveLength(8);
     expect(metar.runwaysInfo[0].name).toBe("27L");
@@ -280,7 +279,7 @@ describe("MetarParser", () => {
     expect(trend.times).toHaveLength(0);
     expect(trend.visibility).toEqual({
       value: 3000,
-      unit: DistanceUnit.Meters
+      unit: DistanceUnit.Meters,
     });
     expect(trend.weatherConditions).toHaveLength(1);
     expect(trend.raw).toBe("TEMPO 26015G25KT 3000 TSRA SCT025CB BKN050");
@@ -359,7 +358,7 @@ describe("MetarParser", () => {
     expect(metar.visibility).toStrictEqual({
       indicator: ValueIndicator.GreaterThan,
       value: 9999,
-      unit: DistanceUnit.Meters
+      unit: DistanceUnit.Meters,
     });
     expect(trend.raw).toBe("TEMPO FM1700 TL1830 SHRA");
   });
@@ -380,8 +379,8 @@ describe("MetarParser", () => {
       unit: DistanceUnit.Meters,
       min: {
         value: 1100,
-        direction: "w"
-      }
+        direction: "w",
+      },
     });
   });
 
@@ -395,7 +394,7 @@ describe("MetarParser", () => {
       speed: 0,
       unit: "KT",
       gust: undefined,
-      direction: "N"
+      direction: "N",
     });
 
     expect(metar.visibility?.min).toBeUndefined();
@@ -423,7 +422,7 @@ describe("MetarParser", () => {
     expect(metar.wind?.degrees).toBe(280);
     expect(metar.visibility).toStrictEqual({
       value: 350,
-      unit: DistanceUnit.Meters
+      unit: DistanceUnit.Meters,
     });
     expect(metar.verticalVisibility).toBe(200);
     expect(metar.weatherConditions[0].phenomenons[0]).toBe(Phenomenon.FOG);
@@ -438,7 +437,7 @@ describe("MetarParser", () => {
       indicator: ValueIndicator.GreaterThan,
       value: 9999,
       unit: DistanceUnit.Meters,
-      ndv: true
+      ndv: true,
     });
   });
 
@@ -451,13 +450,13 @@ describe("MetarParser", () => {
     expect(metar.visibility).toStrictEqual({
       indicator: ValueIndicator.GreaterThan,
       value: 9999,
-      unit: DistanceUnit.Meters
+      unit: DistanceUnit.Meters,
     });
     expect(metar.temperature).toBe(9);
     expect(metar.dewPoint).toBe(6);
     expect(metar.altimeter).toStrictEqual({
       value: 1031,
-      unit: AltimeterUnit.HPa
+      unit: AltimeterUnit.HPa,
     });
     expect(metar.nosig).toBe(true);
   });
@@ -469,7 +468,7 @@ describe("MetarParser", () => {
 
     expect(metar.altimeter).toStrictEqual({
       value: 30.06,
-      unit: AltimeterUnit.InHg
+      unit: AltimeterUnit.InHg,
     });
     expect(metar.weatherConditions).toHaveLength(3);
   });
@@ -546,7 +545,7 @@ describe("MetarParser", () => {
     expect(metar.visibility).toEqual({
       indicator: ValueIndicator.LessThan,
       value: 0.25,
-      unit: DistanceUnit.StatuteMiles
+      unit: DistanceUnit.StatuteMiles,
     });
   });
 
@@ -556,7 +555,7 @@ describe("MetarParser", () => {
     expect(metar.visibility).toEqual({
       indicator: ValueIndicator.GreaterThan,
       value: 6,
-      unit: DistanceUnit.StatuteMiles
+      unit: DistanceUnit.StatuteMiles,
     });
   });
 
@@ -565,7 +564,7 @@ describe("MetarParser", () => {
 
     expect(metar.visibility).toEqual({
       value: 3.25,
-      unit: DistanceUnit.StatuteMiles
+      unit: DistanceUnit.StatuteMiles,
     });
   });
 
@@ -575,7 +574,7 @@ describe("MetarParser", () => {
     expect(metar.visibility).toEqual({
       indicator: ValueIndicator.GreaterThan,
       value: 1.5,
-      unit: DistanceUnit.StatuteMiles
+      unit: DistanceUnit.StatuteMiles,
     });
   });
 
@@ -707,7 +706,7 @@ describe("TAFParser", () => {
 
     expect(taf.visibility).toEqual({
       value: 6000,
-      unit: DistanceUnit.Meters
+      unit: DistanceUnit.Meters,
     });
 
     expect(taf.clouds).toHaveLength(1);
@@ -733,7 +732,7 @@ describe("TAFParser", () => {
     expect(trend0.validity.endHour).toBe(9);
     expect(trend0.visibility).toEqual({
       value: 3000,
-      unit: DistanceUnit.Meters
+      unit: DistanceUnit.Meters,
     });
     expect(trend0.weatherConditions).toHaveLength(1);
     expect(trend0.weatherConditions[0].intensity).toBeUndefined();
@@ -754,7 +753,7 @@ describe("TAFParser", () => {
     expect(trend1.wind).toBeUndefined();
     expect(trend1.visibility).toEqual({
       value: 400,
-      unit: DistanceUnit.Meters
+      unit: DistanceUnit.Meters,
     });
     expect(trend1.weatherConditions).toHaveLength(1);
     expect(trend1.weatherConditions[0].intensity).toBeUndefined();
@@ -775,7 +774,7 @@ describe("TAFParser", () => {
     expect(trend2.validity.endHour).toBe(16);
     expect(trend2.visibility).toEqual({
       value: 4000,
-      unit: DistanceUnit.Meters
+      unit: DistanceUnit.Meters,
     });
     expect(trend2.weatherConditions).toHaveLength(1);
     expect(trend2.weatherConditions[0].intensity).toBe(Intensity.LIGHT);
@@ -808,7 +807,7 @@ describe("TAFParser", () => {
     expect(trend4.validity.endHour).toBe(8);
     expect(trend4.visibility).toEqual({
       value: 3000,
-      unit: DistanceUnit.Meters
+      unit: DistanceUnit.Meters,
     });
     expect(trend4.weatherConditions).toHaveLength(1);
     expect(trend4.weatherConditions[0].intensity).toBeUndefined();
@@ -829,7 +828,7 @@ describe("TAFParser", () => {
     expect(trend5.validity.endHour).toBe(7);
     expect(trend5.visibility).toEqual({
       value: 400,
-      unit: DistanceUnit.Meters
+      unit: DistanceUnit.Meters,
     });
     expect(trend5.weatherConditions).toHaveLength(1);
     expect(trend5.weatherConditions[0].intensity).toBeUndefined();
@@ -872,7 +871,7 @@ describe("TAFParser", () => {
     expect(taf.visibility).toEqual({
       indicator: ValueIndicator.GreaterThan,
       value: 9999,
-      unit: DistanceUnit.Meters
+      unit: DistanceUnit.Meters,
     });
 
     // Checks on clouds
@@ -915,7 +914,7 @@ describe("TAFParser", () => {
     expect(becmg0.validity.endHour).toBe(4);
     expect(becmg0.visibility).toEqual({
       value: 4000,
-      unit: DistanceUnit.Meters
+      unit: DistanceUnit.Meters,
     });
     expect(becmg0.weatherConditions[0].intensity).toBeUndefined();
     expect(becmg0.weatherConditions[0].descriptive).toBe(Descriptive.SHALLOW);
@@ -931,7 +930,7 @@ describe("TAFParser", () => {
     expect(prob0.validity.endHour).toBe(7);
     expect(prob0.visibility).toEqual({
       value: 1500,
-      unit: DistanceUnit.Meters
+      unit: DistanceUnit.Meters,
     });
     expect(prob0.weatherConditions[0].intensity).toBeUndefined();
     expect(prob0.weatherConditions[0].descriptive).toBe(Descriptive.PATCHES);
@@ -951,7 +950,7 @@ describe("TAFParser", () => {
     expect(becmg1.visibility).toEqual({
       indicator: ValueIndicator.GreaterThan,
       value: 9999,
-      unit: DistanceUnit.Meters
+      unit: DistanceUnit.Meters,
     });
     expect(becmg1.weatherConditions).toHaveLength(0);
     expect(becmg1.clouds).toHaveLength(1);
@@ -1000,7 +999,7 @@ describe("TAFParser", () => {
     expect(taf.visibility).toEqual({
       indicator: ValueIndicator.GreaterThan,
       value: 9999,
-      unit: DistanceUnit.Meters
+      unit: DistanceUnit.Meters,
     });
 
     // Checks on clouds
@@ -1034,7 +1033,7 @@ describe("TAFParser", () => {
     expect(becmg1.visibility).toEqual({
       indicator: ValueIndicator.GreaterThan,
       value: 9999,
-      unit: DistanceUnit.Meters
+      unit: DistanceUnit.Meters,
     });
     expect(becmg1.wind?.degrees).toBe(100);
     expect(becmg1.wind?.speed).toBe(10);
@@ -1055,7 +1054,7 @@ describe("TAFParser", () => {
     expect(becmg2.visibility).toEqual({
       indicator: ValueIndicator.GreaterThan,
       value: 9999,
-      unit: DistanceUnit.Meters
+      unit: DistanceUnit.Meters,
     });
     expect(becmg2.wind?.degrees).toBeUndefined();
     expect(becmg2.wind?.speed).toBe(6);
@@ -1112,22 +1111,22 @@ describe("TAFParser", () => {
     // THEN the visibility of the main event is 6 SM
     expect(taf.visibility).toEqual({
       value: 6,
-      unit: DistanceUnit.StatuteMiles
+      unit: DistanceUnit.StatuteMiles,
     });
     // THEN the visibility of the first tempo is 11/2 SM
     expect(taf.trends[0].visibility).toEqual({
       value: 5.5,
-      unit: DistanceUnit.StatuteMiles
+      unit: DistanceUnit.StatuteMiles,
     });
     // THEN the visibility of the second tempo is 3/4 SM
     expect(taf.trends[2].visibility).toEqual({
       value: 0.75,
-      unit: DistanceUnit.StatuteMiles
+      unit: DistanceUnit.StatuteMiles,
     });
     // Then the visibility of the FROM part is 2SN
     expect(taf.trends[1].visibility).toEqual({
       value: 2,
-      unit: DistanceUnit.StatuteMiles
+      unit: DistanceUnit.StatuteMiles,
     });
     expect(taf.amendment).toBe(true);
   });
@@ -1386,7 +1385,7 @@ describe("TAFParser", () => {
     );
     expect(parsed.trends[2].weatherConditions[0].phenomenons).toEqual([
       "DZ",
-      "BR"
+      "BR",
     ]);
     expect(parsed.trends[2].weatherConditions[0].descriptive).toBeUndefined();
   });
@@ -1580,7 +1579,7 @@ describe("RemarkParser", () => {
     expect(remarks[1]).toEqual<Remark>({
       type: RemarkType.AO1,
       description: _("Remark.AO1", en),
-      raw: "AO1"
+      raw: "AO1",
     });
   });
 
@@ -1591,7 +1590,7 @@ describe("RemarkParser", () => {
     expect(remarks[1]).toEqual<Remark>({
       type: RemarkType.AO2,
       description: _("Remark.AO2", en),
-      raw: "AO2"
+      raw: "AO2",
     });
   });
 
@@ -1602,7 +1601,7 @@ describe("RemarkParser", () => {
     expect(remarks[0]).toEqual<Remark>({
       type: RemarkType.AO1,
       description: _("Remark.AO1", en),
-      raw: "AO1"
+      raw: "AO1",
     });
     expect(remarks[1]).toEqual<Remark>({
       type: RemarkType.WindPeak,
@@ -1610,7 +1609,7 @@ describe("RemarkParser", () => {
       raw: "PK WND 28045/15",
       speed: 45,
       degrees: 280,
-      startMinute: 15
+      startMinute: 15,
     });
   });
 
@@ -1621,7 +1620,7 @@ describe("RemarkParser", () => {
     expect(remarks[0]).toEqual<Remark>({
       type: RemarkType.AO1,
       description: _("Remark.AO1", en),
-      raw: "AO1"
+      raw: "AO1",
     });
     expect(remarks[1]).toEqual<Remark>({
       type: RemarkType.WindPeak,
@@ -1630,7 +1629,7 @@ describe("RemarkParser", () => {
       speed: 45,
       degrees: 280,
       startHour: 15,
-      startMinute: 15
+      startMinute: 15,
     });
   });
 
@@ -1642,7 +1641,7 @@ describe("RemarkParser", () => {
       type: RemarkType.WindShift,
       description: format(_("Remark.WindShift.0", en), "", 30),
       raw: "WSHFT 30",
-      startMinute: 30
+      startMinute: 30,
     });
   });
 
@@ -1655,7 +1654,7 @@ describe("RemarkParser", () => {
       description: format(_("Remark.WindShift.0", en), 15, 30),
       raw: "WSHFT 1530",
       startHour: 15,
-      startMinute: 30
+      startMinute: 30,
     });
   });
 
@@ -1668,7 +1667,7 @@ describe("RemarkParser", () => {
       description: format(_("Remark.WindShift.FROPA", en), 15, 30),
       raw: "WSHFT 1530 FROPA",
       startHour: 15,
-      startMinute: 30
+      startMinute: 30,
     });
   });
 
@@ -1680,7 +1679,7 @@ describe("RemarkParser", () => {
       type: RemarkType.WindShiftFropa,
       description: format(_("Remark.WindShift.FROPA", en), "", 30),
       raw: "WSHFT 30 FROPA",
-      startMinute: 30
+      startMinute: 30,
     });
   });
 
@@ -1692,7 +1691,7 @@ describe("RemarkParser", () => {
       type: RemarkType.TowerVisibility,
       description: format(_("Remark.Tower.Visibility", en), "16 1/2"),
       raw: "TWR VIS 16 1/2",
-      distance: 16.5
+      distance: 16.5,
     });
   });
 
@@ -1704,7 +1703,7 @@ describe("RemarkParser", () => {
       type: RemarkType.SurfaceVisibility,
       description: format(_("Remark.Surface.Visibility", en), "16 1/2"),
       raw: "SFC VIS 16 1/2",
-      distance: 16.5
+      distance: 16.5,
     });
   });
 
@@ -1721,7 +1720,7 @@ describe("RemarkParser", () => {
       ),
       raw: "VIS 1/2V2",
       minVisibility: 0.5,
-      maxVisibility: 2
+      maxVisibility: 2,
     });
   });
 
@@ -1738,7 +1737,7 @@ describe("RemarkParser", () => {
       ),
       raw: "VIS NE 2 1/2",
       distance: 2.5,
-      direction: Direction.NE
+      direction: Direction.NE,
     });
   });
 
@@ -1755,7 +1754,7 @@ describe("RemarkParser", () => {
       ),
       raw: "VIS 2 1/2 RWY11",
       distance: 2.5,
-      location: "RWY11"
+      location: "RWY11",
     });
   });
 
@@ -1777,7 +1776,7 @@ describe("RemarkParser", () => {
       tornadicType: "TORNADO",
       startMinute: 13,
       distance: 6,
-      direction: Direction.NE
+      direction: Direction.NE,
     });
   });
 
@@ -1800,7 +1799,7 @@ describe("RemarkParser", () => {
       startHour: 15,
       startMinute: 13,
       distance: 6,
-      direction: Direction.NE
+      direction: Direction.NE,
     });
   });
 
@@ -1829,7 +1828,7 @@ describe("RemarkParser", () => {
       endHour: 16,
       endMinute: 30,
       distance: 6,
-      direction: Direction.NE
+      direction: Direction.NE,
     });
   });
 
@@ -1851,7 +1850,7 @@ describe("RemarkParser", () => {
       tornadicType: "WATERSPOUT",
       endMinute: 16,
       distance: 12,
-      direction: Direction.NE
+      direction: Direction.NE,
     });
   });
 
@@ -1874,7 +1873,7 @@ describe("RemarkParser", () => {
       endHour: 15,
       endMinute: 16,
       distance: 12,
-      direction: Direction.NE
+      direction: Direction.NE,
     });
   });
 
@@ -1896,7 +1895,7 @@ describe("RemarkParser", () => {
       raw: "RAB05E30",
       phenomenon: Phenomenon.RAIN,
       startMin: 5,
-      endMin: 30
+      endMin: 30,
     });
     expect(remarks[2]).toEqual<Remark>({
       type: RemarkType.PrecipitationBegEnd,
@@ -1914,7 +1913,7 @@ describe("RemarkParser", () => {
       startHour: 15,
       startMin: 20,
       endHour: 16,
-      endMin: 55
+      endMin: 55,
     });
   });
 
@@ -1937,7 +1936,7 @@ describe("RemarkParser", () => {
       descriptive: Descriptive.SHOWERS,
       phenomenon: Phenomenon.RAIN,
       startMin: 5,
-      endMin: 30
+      endMin: 30,
     });
     expect(remarks[2]).toEqual<Remark>({
       type: RemarkType.PrecipitationBegEnd,
@@ -1954,7 +1953,7 @@ describe("RemarkParser", () => {
       descriptive: Descriptive.SHOWERS,
       phenomenon: Phenomenon.SNOW,
       startMin: 20,
-      endMin: 55
+      endMin: 55,
     });
   });
 
@@ -1974,7 +1973,7 @@ describe("RemarkParser", () => {
       raw: "SHRAB05",
       descriptive: Descriptive.SHOWERS,
       phenomenon: Phenomenon.RAIN,
-      startMin: 5
+      startMin: 5,
     });
     expect(remarks[2]).toEqual<Remark>({
       type: RemarkType.PrecipitationBeg,
@@ -1989,7 +1988,7 @@ describe("RemarkParser", () => {
       descriptive: Descriptive.SHOWERS,
       phenomenon: Phenomenon.SNOW,
       startHour: 2,
-      startMin: 20
+      startMin: 20,
     });
   });
 
@@ -2011,7 +2010,7 @@ describe("RemarkParser", () => {
       raw: "SHRAE05",
       descriptive: Descriptive.SHOWERS,
       phenomenon: Phenomenon.RAIN,
-      endMin: 5
+      endMin: 5,
     });
     expect(remarks[2]).toEqual<Remark>({
       type: RemarkType.PrecipitationEnd,
@@ -2026,7 +2025,7 @@ describe("RemarkParser", () => {
       descriptive: Descriptive.SHOWERS,
       phenomenon: Phenomenon.SNOW,
       endHour: 1,
-      endMin: 20
+      endMin: 20,
     });
   });
 
@@ -2049,7 +2048,7 @@ describe("RemarkParser", () => {
       phenomenon: Phenomenon.THUNDERSTORM,
       startHour: 1,
       startMin: 59,
-      endMin: 30
+      endMin: 30,
     });
   });
 
@@ -2064,7 +2063,7 @@ describe("RemarkParser", () => {
         _("Converter.SE", en)
       ),
       raw: "TS SE",
-      location: Direction.SE
+      location: Direction.SE,
     });
   });
 
@@ -2081,7 +2080,7 @@ describe("RemarkParser", () => {
       ),
       raw: "TS SE MOV NE",
       location: Direction.SE,
-      moving: Direction.NE
+      moving: Direction.NE,
     });
   });
 
@@ -2093,7 +2092,7 @@ describe("RemarkParser", () => {
       type: RemarkType.HailSize,
       description: format(_("Remark.Hail.0", en), "1 3/4"),
       raw: "GR 1 3/4",
-      size: 1.75
+      size: 1.75,
     });
   });
 
@@ -2105,7 +2104,7 @@ describe("RemarkParser", () => {
       type: RemarkType.SmallHailSize,
       description: format(_("Remark.Hail.LesserThan", en), "1/4"),
       raw: "GR LESS THAN 1/4",
-      size: 0.25
+      size: 0.25,
     });
   });
 
@@ -2117,7 +2116,7 @@ describe("RemarkParser", () => {
       type: RemarkType.SnowPellets,
       description: format(_("Remark.Snow.Pellets", en), _("Remark.MOD", en)),
       raw: "GS MOD",
-      amount: "MOD"
+      amount: "MOD",
     });
   });
 
@@ -2132,7 +2131,7 @@ describe("RemarkParser", () => {
         _("Converter.SW", en)
       ),
       raw: "VIRGA SW",
-      direction: Direction.SW
+      direction: Direction.SW,
     });
   });
 
@@ -2143,7 +2142,7 @@ describe("RemarkParser", () => {
     expect(remarks[1]).toEqual<Remark>({
       type: RemarkType.VIRGA,
       description: format(_("Remark.VIRGA", en)),
-      raw: "VIRGA"
+      raw: "VIRGA",
     });
   });
 
@@ -2156,7 +2155,7 @@ describe("RemarkParser", () => {
       description: format(_("Remark.Ceiling.Height", en), 500, 1000),
       raw: "CIG 005V010",
       min: 500,
-      max: 1000
+      max: 1000,
     });
   });
 
@@ -2175,7 +2174,7 @@ describe("RemarkParser", () => {
       raw: "FU BKN020",
       quantity: CloudQuantity.BKN,
       height: 2000,
-      phenomenon: Phenomenon.SMOKE
+      phenomenon: Phenomenon.SMOKE,
     });
   });
 
@@ -2190,7 +2189,7 @@ describe("RemarkParser", () => {
         _("CloudQuantity.OVC", en)
       ),
       raw: "BKN V OVC",
-      cloudQuantityRange: [CloudQuantity.BKN, CloudQuantity.OVC]
+      cloudQuantityRange: [CloudQuantity.BKN, CloudQuantity.OVC],
     });
   });
 
@@ -2207,7 +2206,7 @@ describe("RemarkParser", () => {
       ),
       raw: "BKN014 V OVC",
       cloudQuantityRange: [CloudQuantity.BKN, CloudQuantity.OVC],
-      height: 1400
+      height: 1400,
     });
   });
 
@@ -2223,7 +2222,7 @@ describe("RemarkParser", () => {
       ),
       raw: "CIG 002 RWY11",
       height: 200,
-      location: "RWY11"
+      location: "RWY11",
     });
   });
 
@@ -2234,7 +2233,7 @@ describe("RemarkParser", () => {
       type: RemarkType.SeaLevelPressure,
       description: format(_("Remark.Sea.Level.Pressure", en), "1013.4"),
       raw: "SLP134",
-      pressure: 1013.4
+      pressure: 1013.4,
     });
   });
 
@@ -2245,7 +2244,7 @@ describe("RemarkParser", () => {
       type: RemarkType.SeaLevelPressure,
       description: format(_("Remark.Sea.Level.Pressure", en), "998.2"),
       raw: "SLP982",
-      pressure: 998.2
+      pressure: 998.2,
     });
   });
 
@@ -2257,7 +2256,7 @@ describe("RemarkParser", () => {
       description: format(_("Remark.Snow.Increasing.Rapidly", en), 2, 10),
       raw: "SNINCR 2/10",
       inchesLastHour: 2,
-      totalDepth: 10
+      totalDepth: 10,
     });
   });
 
@@ -2270,7 +2269,7 @@ describe("RemarkParser", () => {
       type: RemarkType.SeaLevelPressure,
       description: format(_("Remark.Sea.Level.Pressure", en), "1009.1"),
       raw: "SLP091",
-      pressure: 1009.1
+      pressure: 1009.1,
     });
   });
 
@@ -2283,7 +2282,7 @@ describe("RemarkParser", () => {
         "24-hour maximum temperature of 10.0°C and 24-hour minimum temperature of -1.5°C",
       raw: "401001015",
       max: 10,
-      min: -1.5
+      min: -1.5,
     });
   });
 
@@ -2294,7 +2293,7 @@ describe("RemarkParser", () => {
       type: RemarkType.HourlyMaximumTemperature,
       description: "6-hourly maximum temperature of -2.1°C",
       raw: "11021",
-      max: -2.1
+      max: -2.1,
     });
   });
 
@@ -2305,7 +2304,7 @@ describe("RemarkParser", () => {
       type: RemarkType.HourlyMaximumTemperature,
       description: "6-hourly maximum temperature of 14.2°C",
       raw: "10142",
-      max: 14.2
+      max: 14.2,
     });
   });
 
@@ -2316,7 +2315,7 @@ describe("RemarkParser", () => {
       type: RemarkType.HourlyMinimumTemperature,
       description: "6-hourly minimum temperature of -0.1°C",
       raw: "21001",
-      min: -0.1
+      min: -0.1,
     });
   });
 
@@ -2327,7 +2326,7 @@ describe("RemarkParser", () => {
       type: RemarkType.HourlyMinimumTemperature,
       description: "6-hourly minimum temperature of 1.2°C",
       raw: "20012",
-      min: 1.2
+      min: 1.2,
     });
   });
 
@@ -2340,7 +2339,7 @@ describe("RemarkParser", () => {
         "steady or unsteady increase of 3.2 hectopascals in the past 3 hours",
       raw: "52032",
       code: 2,
-      pressureChange: 3.2
+      pressureChange: 3.2,
     });
   });
 
@@ -2351,7 +2350,7 @@ describe("RemarkParser", () => {
       type: RemarkType.PrecipitationAmount24Hour,
       description: "1.25 inches of precipitation fell in the last 24 hours",
       raw: "70125",
-      amount: 1.25
+      amount: 1.25,
     });
   });
 
@@ -2362,7 +2361,7 @@ describe("RemarkParser", () => {
       type: RemarkType.SnowDepth,
       description: "snow depth of 21 inches",
       raw: "4/021",
-      depth: 21
+      depth: 21,
     });
   });
 
@@ -2373,7 +2372,7 @@ describe("RemarkParser", () => {
       type: RemarkType.SunshineDuration,
       description: "96 minutes of sunshine",
       raw: "98096",
-      duration: 96
+      duration: 96,
     });
   });
 
@@ -2384,7 +2383,7 @@ describe("RemarkParser", () => {
       type: RemarkType.WaterEquivalentSnow,
       description: "water equivalent of 3.6 inches of snow",
       raw: "933036",
-      amount: 3.6
+      amount: 3.6,
     });
   });
 
@@ -2396,7 +2395,7 @@ describe("RemarkParser", () => {
       description: "4/100 of an inch of ice accretion in the past 1 hour(s)",
       raw: "l1004",
       amount: 0.04,
-      periodInHours: 1
+      periodInHours: 1,
     });
   });
 
@@ -2407,7 +2406,7 @@ describe("RemarkParser", () => {
       type: RemarkType.HourlyTemperatureDewPoint,
       description: "hourly temperature of 2.6°C",
       raw: "T0026",
-      temperature: 2.6
+      temperature: 2.6,
     });
   });
 
@@ -2419,7 +2418,7 @@ describe("RemarkParser", () => {
       description: "hourly temperature of 2.6°C and dew point of -1.5°C",
       raw: "T00261015",
       temperature: 2.6,
-      dewPoint: -1.5
+      dewPoint: -1.5,
     });
   });
 
@@ -2431,7 +2430,7 @@ describe("RemarkParser", () => {
       description: "2.17 inches of precipitation fell in the last 3 hours",
       raw: "30217",
       amount: 2.17,
-      periodInHours: 3
+      periodInHours: 3,
     });
   });
 
@@ -2443,7 +2442,7 @@ describe("RemarkParser", () => {
       description: "2.17 inches of precipitation fell in the last 6 hours",
       raw: "60217",
       amount: 2.17,
-      periodInHours: 6
+      periodInHours: 6,
     });
   });
 
@@ -2455,7 +2454,7 @@ describe("RemarkParser", () => {
       "      BECMG 0917/0919 23017KT SCT020 ",
       "      BECMG 0921/0923 27008KT BKN025 ",
       "      BECMG 1004/1006 5000 BR BKN010 ",
-      "      RMK PHP"
+      "      RMK PHP",
     ].join("\n");
     try {
       new TAFParser(en).parse(input);


### PR DESCRIPTION
Addresses #68 by (probably overly carefully) checking for `PART x OF y` at start of TAF and throwing a new exception type, `UnsupportedWeatherStatementError` when found. The exception includes a `reason` which should make it easy for clients to understand what went wrong.