### PR TITLE
Add support for three-digit gust reports

### DIFF
--- a/src/command/common.ts
+++ b/src/command/common.ts
@@ -98,7 +98,7 @@ export class MainVisibilityCommand implements ICommand {
 }
 
 export class WindCommand implements ICommand {
-  #regex = /^(VRB|00|[0-3]\d{2})(\d{2})G?(\d{2})?(KT|MPS|KM\/H)?/;
+  #regex = /^(VRB|00|[0-3]\d{2})(\d{2})G?(\d{2,3})?(KT|MPS|KM\/H)?/;
 
   canParse(windString: string): boolean {
     return this.#regex.test(windString);
@@ -149,7 +149,7 @@ export class WindVariationCommand implements ICommand {
 }
 
 export class WindShearCommand implements ICommand {
-  #regex = /^WS(\d{3})\/(\w{3})(\d{2})G?(\d{2})?(KT|MPS|KM\/H)/;
+  #regex = /^WS(\d{3})\/(\w{3})(\d{2})G?(\d{2,3})?(KT|MPS|KM\/H)/;
 
   canParse(windString: string): boolean {
     return this.#regex.test(windString);

--- a/tests/command/common.test.ts
+++ b/tests/command/common.test.ts
@@ -208,7 +208,7 @@ describe("WindCommand", () => {
       });
     });
   })();
-  
+
   (() => {
     const code = "12017G015KT";
 

--- a/tests/command/common.test.ts
+++ b/tests/command/common.test.ts
@@ -208,6 +208,26 @@ describe("WindCommand", () => {
       });
     });
   })();
+  
+  (() => {
+    const code = "12017G015KT";
+
+    describe(code, () => {
+      test("canParse", () => {
+        expect(command.canParse(code)).toBe(true);
+      });
+
+      test("parse", () => {
+        const wind = command.parseWind(code);
+
+        expect(wind.direction).toBe("ESE");
+        expect(wind.degrees).toBe(120);
+        expect(wind.speed).toBe(17);
+        expect(wind.gust).toBe(15);
+        expect(wind.unit).toBe("KT");
+      });
+    });
+  })();
 
   (() => {
     const code = "VRB08KT";


### PR DESCRIPTION
Parsing the following (simplified) report yields a gust value of `4`, which seems to be incorrect.

[RKPM 091931Z 34028G043KT](https://aeharding.github.io/metar-taf-parser/metar?input=RKPM+091931Z+34028G043KT)

I did some research, and while I found it hard to find "official" sources, I believe that I have found ones that are reputable _enough_. There also seems to be some degree of disagreement between sources, but I think it would be safe to support an extra digit regardless, as it seems that this does in fact occur in real reports.

Here are some extracts from a few sources with varying amounts of explicit specifications:

>The maximum gust during the sampling period is reported when it exceeds the mean speed by 10 knots or more. It is indicated by the letter G which is followed by the gust value.
> <small>http://www.bom.gov.au/aviation/data/education/metar-speci.pdf</small>

> If gusts exceed the mean wind speed by 10kts or more in the 10 minutes preceding the time of the report, a letter **G** and 2 more figures are added to indicate the maximum wind speed
> <small>https://skybrary.aero/articles/meteorological-aerodrome-report-metar</small>

> **Gf<sub>m</sub>f<sub>m</sub>** will be included if gust speeds exceed the mean speed by 10 knots or more in the 10-minute period preceding the observation. If this condition is not met, **Gf<sub>m</sub>f<sub>m</sub>** is omitted. **G** indicates gusts and **f<sub>m</sub>f<sub>m</sub>** is the peak gust reported, using two or three digits as required.
> <small>https://meteocentre.com/doc/metar.html</small>

This PR optionally includes a 3rd digit in the pattern match for gust values. I also added a test, and made sure that I did not break any of the existing ones!

