### PR TITLE
Fix parsing of "calm wind"

### DIFF
--- a/src/command/common.ts
+++ b/src/command/common.ts
@@ -98,7 +98,7 @@ export class MainVisibilityCommand implements ICommand {
 }
 
 export class WindCommand implements ICommand {
-  #regex = /^(VRB|00|[0-3]\d{2})(\d{2})G?(\d{2,3})?(KT|MPS|KM\/H)?/;
+  #regex = /^(VRB|000|[0-3]\d{2})(\d{2})G?(\d{2,3})?(KT|MPS|KM\/H)?/;
 
   canParse(windString: string): boolean {
     return this.#regex.test(windString);

--- a/tests/parser/parser.test.ts
+++ b/tests/parser/parser.test.ts
@@ -386,7 +386,7 @@ describe("MetarParser", () => {
 
   test("wind of 0000KT should not parse as minVisibility", () => {
     const metar = new MetarParser(en).parse(
-      "KATW 022045Z 0000KT 10SM SCT120 00/M08 A2996"
+      "KATW 022045Z 00000KT 10SM SCT120 00/M08 A2996"
     );
 
     expect(metar.wind).toStrictEqual({

--- a/tests/parser/parser.test.ts
+++ b/tests/parser/parser.test.ts
@@ -399,7 +399,7 @@ describe("MetarParser", () => {
 
     expect(metar.visibility?.min).toBeUndefined();
   });
-
+  
   test("wind of 00000MPS should parse with correct unit", () => {
     const metar = new MetarParser(en).parse("KATL 270200Z 00000MPS");
 
@@ -410,6 +410,20 @@ describe("MetarParser", () => {
       gust: undefined,
       direction: "N",
     });
+  });
+
+  test("visibility should not parse as wind speed", () => {
+    const metar = new MetarParser(en).parse("VIDP 270200Z 00000MPS 0050");
+
+    expect(metar.wind).toStrictEqual({
+      degrees: 0,
+      speed: 0,
+      unit: "MPS",
+      gust: undefined,
+      direction: "N",
+    });
+
+    expect(metar.visibility).toStrictEqual({ unit: "m", value: 50 });
   });
 
   test("wind variation", () => {

--- a/tests/parser/parser.test.ts
+++ b/tests/parser/parser.test.ts
@@ -400,6 +400,18 @@ describe("MetarParser", () => {
     expect(metar.visibility?.min).toBeUndefined();
   });
 
+  test("wind of 00000MPS should parse with correct unit", () => {
+    const metar = new MetarParser(en).parse("KATL 270200Z 00000MPS");
+
+    expect(metar.wind).toStrictEqual({
+      degrees: 0,
+      speed: 0,
+      unit: "MPS",
+      gust: undefined,
+      direction: "N",
+    });
+  });
+
   test("wind variation", () => {
     const metar = new MetarParser(en).parse("LFPG 161430Z 24015G25KT 180V300");
 

--- a/tests/parser/parser.test.ts
+++ b/tests/parser/parser.test.ts
@@ -399,7 +399,7 @@ describe("MetarParser", () => {
 
     expect(metar.visibility?.min).toBeUndefined();
   });
-  
+
   test("wind of 00000MPS should parse with correct unit", () => {
     const metar = new MetarParser(en).parse("KATL 270200Z 00000MPS");
 


### PR DESCRIPTION
This PR fixes a small issue introduced earlier this year in https://github.com/aeharding/metar-taf-parser/pull/66

  The METAR mentioned in this issue was `KATW 022045Z 0000KT 10SM SCT120 00/M08 A2996`, which contains an invalid "winds calm" value according to the [Federal Meteorological Handbook](https://www.icams-portal.gov/resources/ofcm/fmh/FMH1/fmh1_2019.pdf):
  
  > d) Calm Wind. Calm wind shall be coded as "00000KT"
The first three zeros represent the wind direction and the last two zeros represent the speed.

Those changes to the regex prevented correct unit parsing for _correct_ reports and introduced a bug where visibility values would be mistaken for wind speed.

This has been fixed upstream: https://github.com/mivek/python-metar-taf-parser/pull/63

Fixes #79 , fixes #80 