### PR TITLE
Ensure flight category calculations adheres to standards

### DIFF
--- a/example/src/helpers/metarTaf.ts
+++ b/example/src/helpers/metarTaf.ts
@@ -230,8 +230,8 @@ export function getFlightCategory(
   let flightCategory = FlightCategory.VFR;
 
   if (height <= 3000 || distance <= 5) flightCategory = FlightCategory.MVFR;
-  if (height <= 1000 || distance <= 3) flightCategory = FlightCategory.IFR;
-  if (height <= 500 || distance <= 1) flightCategory = FlightCategory.LIFR;
+  if (height < 1000 || distance < 3) flightCategory = FlightCategory.IFR;
+  if (height < 500 || distance < 1) flightCategory = FlightCategory.LIFR;
 
   return flightCategory;
 }


### PR DESCRIPTION
The current logic does not align with the specification:

![FAA Flight Category spec](https://www.faasafety.gov/files/gslac/library/documents/2006/Oct/9091/PersMins%20Wx%20Review.gif)

This PR should include the necessary changes to make it correctly align with expectations.