### PR TITLE
Fix/103 add support for next forecast by remark

### DIFF
--- a/src/command/remark.ts
+++ b/src/command/remark.ts
@@ -148,6 +148,11 @@ import {
   IPrecipitationEndRemark,
   PrecipitationEndCommand,
 } from "./remark/PrecipitationEndCommand";
+import {
+  INextForecastByRemark,
+  INextForecastByRemarkDated,
+  NextForecastByCommand
+} from "command/remark/NextForecastByCommand";
 
 export type {
   ICeilingHeightRemark,
@@ -184,6 +189,8 @@ export type {
   IWaterEquivalentSnowRemark,
   IWindPeakCommandRemark,
   IWindShiftFropaRemark,
+  INextForecastByRemark,
+  INextForecastByRemarkDated,
 };
 
 export interface IBaseRemark {
@@ -242,6 +249,7 @@ export class RemarkCommandSupplier {
       new SnowDepthCommand(locale),
       new SunshineDurationCommand(locale),
       new WaterEquivalentSnowCommand(locale),
+      new NextForecastByCommand(locale),
     ];
   }
 
@@ -308,6 +316,9 @@ export enum RemarkType {
   SnowDepth = "SnowDepth",
   SunshineDuration = "SunshineDuration",
   WaterEquivalentSnow = "WaterEquivalentSnow",
+
+  // Canada commands below
+  NextForecastBy = "NextForecastBy",
 }
 
 export type Remark =
@@ -326,7 +337,6 @@ export type Remark =
   | IIceAccretionRemark
   | IObscurationRemark
   | IPrecipitationAmount24HourRemark
-  | IPrecipitationAmount36HourRemark
   | IPrecipitationAmount36HourRemark
   | IPrecipitationBegRemark
   | IPrecipitationBegEndRemark
@@ -353,4 +363,7 @@ export type Remark =
   | IWaterEquivalentSnowRemark
   | IWindPeakCommandRemark
   | IWindShiftRemark
-  | IWindShiftFropaRemark;
+  | IWindShiftFropaRemark
+  // Canadian commands below
+  | INextForecastByRemark
+  | INextForecastByRemarkDated;

--- a/src/command/remark.ts
+++ b/src/command/remark.ts
@@ -321,7 +321,8 @@ export enum RemarkType {
   NextForecastBy = "NextForecastBy",
 }
 
-export type Remark =
+// Remark types that are not date based
+export type RemarkBase =
   | IUnknownRemark
   | IDefaultCommandRemark
   // Regular commands below
@@ -363,7 +364,14 @@ export type Remark =
   | IWaterEquivalentSnowRemark
   | IWindPeakCommandRemark
   | IWindShiftRemark
-  | IWindShiftFropaRemark
+  | IWindShiftFropaRemark;
+
+export type RemarkDated =
+  | RemarkBase
   // Canadian commands below
-  | INextForecastByRemark
   | INextForecastByRemarkDated;
+
+export type Remark =
+  | RemarkBase
+  // Canadian commands below
+  | INextForecastByRemark;

--- a/src/command/remark.ts
+++ b/src/command/remark.ts
@@ -151,7 +151,7 @@ import {
 import {
   INextForecastByRemark,
   INextForecastByRemarkDated,
-  NextForecastByCommand
+  NextForecastByCommand,
 } from "command/remark/NextForecastByCommand";
 
 export type {

--- a/src/command/remark.ts
+++ b/src/command/remark.ts
@@ -322,7 +322,7 @@ export enum RemarkType {
 }
 
 // Remark types that are not date based
-export type RemarkBase =
+type RemarkBase =
   | IUnknownRemark
   | IDefaultCommandRemark
   // Regular commands below

--- a/src/command/remark/NextForecastByCommand.ts
+++ b/src/command/remark/NextForecastByCommand.ts
@@ -14,7 +14,7 @@ export interface INextForecastByRemark extends IBaseRemark {
 export interface INextForecastByRemarkDated extends INextForecastByRemark {
   type: RemarkType.NextForecastBy;
 
-  date: Date,
+  date: Date;
 }
 
 export class NextForecastByCommand extends Command {

--- a/src/command/remark/NextForecastByCommand.ts
+++ b/src/command/remark/NextForecastByCommand.ts
@@ -1,0 +1,55 @@
+import { format, _ } from "commons/i18n";
+import { UnexpectedParseError } from "commons/errors";
+import { IBaseRemark, RemarkType, Remark } from "../remark";
+import { Command } from "./Command";
+
+export interface INextForecastByRemark extends IBaseRemark {
+  type: RemarkType.NextForecastBy;
+
+  day: number;
+  hour: number;
+  minute: number;
+}
+
+export interface INextForecastByRemarkDated extends INextForecastByRemark {
+  type: RemarkType.NextForecastBy;
+
+  date: Date,
+}
+
+export class NextForecastByCommand extends Command {
+  #regex = /^NXT FCST BY (\d{2})(\d{2})(\d{2})Z/;
+
+  canParse(code: string): boolean {
+    return this.#regex.test(code);
+  }
+
+  execute(code: string, remark: Remark[]): [string, Remark[]] {
+    const matches = code.match(this.#regex);
+
+    if (!matches) throw new UnexpectedParseError("Match not found");
+
+    const day = +matches[1];
+    const hour = matches[2];
+    const minute = matches[3];
+
+    const description = format(
+      _("Remark.Next.Forecast.By", this.locale),
+      day,
+      hour,
+      minute,
+    );
+
+    remark.push({
+      type: RemarkType.NextForecastBy,
+      description,
+      raw: matches[0],
+
+      day,
+      hour: +hour,
+      minute: +minute,
+    });
+
+    return [code.replace(this.#regex, "").trim(), remark];
+  }
+}

--- a/src/dates/metar.ts
+++ b/src/dates/metar.ts
@@ -1,6 +1,6 @@
 import { IMetar } from "model/model";
 import { determineReportDate } from "helpers/date";
-import {RemarkType} from "command/remark";
+import { RemarkType } from "command/remark";
 
 export interface IMetarDated extends IMetar {
   issued: Date;

--- a/src/dates/metar.ts
+++ b/src/dates/metar.ts
@@ -1,5 +1,6 @@
 import { IMetar } from "model/model";
 import { determineReportDate } from "helpers/date";
+import {RemarkType} from "command/remark";
 
 export interface IMetarDated extends IMetar {
   issued: Date;
@@ -8,6 +9,21 @@ export interface IMetarDated extends IMetar {
 export function metarDatesHydrator(report: IMetar, date: Date): IMetarDated {
   return {
     ...report,
+    remarks: report.remarks.map((remark) => {
+      if (remark.type === RemarkType.NextForecastBy) {
+        return {
+          ...remark,
+          date: determineReportDate(
+            date,
+            remark.day,
+            remark.hour,
+            remark.minute,
+          ),
+        };
+      } else {
+        return remark;
+      }
+    }),
     issued: determineReportDate(date, report.day, report.hour, report.minute),
   };
 }

--- a/src/dates/metar.ts
+++ b/src/dates/metar.ts
@@ -1,6 +1,5 @@
 import { IMetar } from "model/model";
 import { determineReportDate } from "helpers/date";
-import { RemarkType } from "command/remark";
 
 export interface IMetarDated extends IMetar {
   issued: Date;
@@ -9,21 +8,6 @@ export interface IMetarDated extends IMetar {
 export function metarDatesHydrator(report: IMetar, date: Date): IMetarDated {
   return {
     ...report,
-    remarks: report.remarks.map((remark) => {
-      if (remark.type === RemarkType.NextForecastBy) {
-        return {
-          ...remark,
-          date: determineReportDate(
-            date,
-            remark.day,
-            remark.hour,
-            remark.minute,
-          ),
-        };
-      } else {
-        return remark;
-      }
-    }),
     issued: determineReportDate(date, report.day, report.hour, report.minute),
   };
 }

--- a/src/dates/taf.ts
+++ b/src/dates/taf.ts
@@ -8,7 +8,7 @@ import {
   ITemperatureDated,
 } from "model/model";
 import { determineReportDate } from "helpers/date";
-import {RemarkType} from "command/remark";
+import { RemarkType } from "command/remark";
 
 export type TAFTrendDated = IAbstractTrend &
   IBaseTAFTrend & {

--- a/src/dates/taf.ts
+++ b/src/dates/taf.ts
@@ -8,6 +8,7 @@ import {
   ITemperatureDated,
 } from "model/model";
 import { determineReportDate } from "helpers/date";
+import {RemarkType} from "command/remark";
 
 export type TAFTrendDated = IAbstractTrend &
   IBaseTAFTrend & {
@@ -93,6 +94,21 @@ export function tafDatesHydrator(report: ITAF, date: Date): ITAFDated {
       (trend) =>
         ({
           ...trend,
+          remarks: trend.remarks.map((remark) => {
+            if (remark.type === RemarkType.NextForecastBy) {
+              return {
+                ...remark,
+                date: determineReportDate(
+                  issued,
+                  remark.day,
+                  remark.hour,
+                  remark.minute,
+                ),
+              };
+            } else {
+              return remark;
+            }
+          }),
           validity: (() => {
             switch (trend.type) {
               case WeatherChangeType.FM:

--- a/src/dates/taf.ts
+++ b/src/dates/taf.ts
@@ -105,9 +105,8 @@ export function tafDatesHydrator(report: ITAF, date: Date): ITAFDated {
                   remark.minute,
                 ),
               };
-            } else {
-              return remark;
             }
+            return remark;
           }),
           validity: (() => {
             switch (trend.type) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export {
   IBaseRemark,
   IUnknownRemark,
   Remark,
+  RemarkDated,
   // Rest of remark types
   ICeilingHeightRemark,
   ICeilingSecondLocationRemark,
@@ -52,6 +53,9 @@ export {
   IWaterEquivalentSnowRemark,
   IWindPeakCommandRemark,
   IWindShiftFropaRemark,
+  // Canadian remarks
+  INextForecastByRemark,
+  INextForecastByRemarkDated,
 } from "command/remark";
 export {
   getCompositeForecastForDate,

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -195,6 +195,11 @@ export default {
     LGT: "light",
     LTG: "lightning",
     MOD: "moderate",
+    Next: {
+      Forecast: {
+        By: "next forecast by {0}, {1}:{2}Z"
+      },
+    },
     NXT: "next",
     ON: "on",
     Obscuration: "{0} layer at {1} feet composed of {2}",

--- a/tests/command/remark/NextForecastByCommand.test.ts
+++ b/tests/command/remark/NextForecastByCommand.test.ts
@@ -1,0 +1,31 @@
+import en from "locale/en";
+import { Remark, RemarkType } from "command/remark";
+import { NextForecastByCommand } from "command/remark/NextForecastByCommand";
+
+describe("NextForecastByCommand", () => {
+  const command = new NextForecastByCommand(en);
+  const code = "NXT FCST BY 160300Z";
+
+  describe(code, () => {
+    test("canParse", () => {
+      expect(command.canParse(code)).toBe(true);
+    });
+
+    test("execute", () => {
+      const [res, remarks] = command.execute(code, []);
+
+      expect(res).toBe("");
+      expect(remarks).toEqual<Remark[]>([
+        {
+          type: RemarkType.NextForecastBy,
+          description: "next forecast by 16, 03:00Z",
+          raw: code,
+
+          day: 16,
+          hour: 3,
+          minute: 0,
+        },
+      ]);
+    });
+  });
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -4,6 +4,7 @@ import {
   parseTAFAsForecast,
   WeatherChangeType,
 } from "index";
+import {INextForecastByRemarkDated} from "command/remark/NextForecastByCommand";
 
 describe("public API", () => {
   describe("parseMetar", () => {
@@ -57,6 +58,20 @@ TAF
           new Date("2022-01-16T18:00:00.000Z"),
         );
       });
+
+      test("sets next forecasted by remark date", () => {
+        const taf = parseTAF(
+          `
+    TAF CYVR 152340Z 1600/1706 29015KT P6SM FEW015 FM162200 28010KT P6SM SKC RMK NXT FCST BY 160300Z
+        `,
+          { issued: new Date("2022-10-22") },
+        );
+        expect(taf.trends[0]).toBeDefined();
+        expect(taf.trends[0].remarks[0]).toBeDefined();
+        expect((taf.trends[0].remarks[0] as INextForecastByRemarkDated).date).toEqual(
+          new Date("2022-10-16T03:00:00.000Z"),
+        );
+      })
 
       test("should set maxTemperature, minTemperature with dates", () => {
         const taf = parseTAF(

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -4,7 +4,7 @@ import {
   parseTAFAsForecast,
   WeatherChangeType,
 } from "index";
-import {INextForecastByRemarkDated} from "command/remark/NextForecastByCommand";
+import { INextForecastByRemarkDated } from "command/remark/NextForecastByCommand";
 
 describe("public API", () => {
   describe("parseMetar", () => {
@@ -68,10 +68,10 @@ TAF
         );
         expect(taf.trends[0]).toBeDefined();
         expect(taf.trends[0].remarks[0]).toBeDefined();
-        expect((taf.trends[0].remarks[0] as INextForecastByRemarkDated).date).toEqual(
-          new Date("2022-10-16T03:00:00.000Z"),
-        );
-      })
+        expect(
+          (taf.trends[0].remarks[0] as INextForecastByRemarkDated).date,
+        ).toEqual(new Date("2022-10-16T03:00:00.000Z"));
+      });
 
       test("should set maxTemperature, minTemperature with dates", () => {
         const taf = parseTAF(

--- a/tests/parser/parser.test.ts
+++ b/tests/parser/parser.test.ts
@@ -1199,7 +1199,7 @@ describe("TAFParser", () => {
 
     expect(taf).toBeDefined();
     expect(taf.remark).toBeDefined();
-    expect(taf.remarks).toHaveLength(1);
+    expect(taf.remarks).toHaveLength(2);
   });
 
   test("parse with trend remark", () => {
@@ -1209,7 +1209,7 @@ describe("TAFParser", () => {
 
     expect(taf.trends).toHaveLength(3);
     expect(taf.trends[2].remark).toBeDefined();
-    expect(taf.trends[2].remarks).toHaveLength(1);
+    expect(taf.trends[2].remarks).toHaveLength(2);
   });
 
   test("parses INTER trend", () => {

--- a/tests/parser/parser.test.ts
+++ b/tests/parser/parser.test.ts
@@ -36,7 +36,7 @@ import { PartialWeatherStatementError } from "commons/errors";
 
 describe("RemarkParser", () => {
   (() => {
-    const code = "Token AO1 End of remark";
+    const code = "Token AO1 End of remark NXT FCST BY 160300Z";
 
     test(`parses "${code}"`, () => {
       const remarks = new RemarkParser(en).parse(code);
@@ -54,6 +54,14 @@ describe("RemarkParser", () => {
         {
           type: RemarkType.Unknown,
           raw: "End of remark",
+        },
+        {
+          type: RemarkType.NextForecastBy,
+          description: "next forecast by 16, 03:00Z",
+          raw: "NXT FCST BY 160300Z",
+          day: 16,
+          hour: 3,
+          minute: 0,
         },
       ]);
     });


### PR DESCRIPTION
Added support to parse the `NXT FCST BY ` remark often found in canadian TAFs. This effectively fixes #103 