### PR TITLE
Added support for a value indicator for rvr range reports (fixes #117)

### DIFF
--- a/src/command/metar/RunwayCommand.ts
+++ b/src/command/metar/RunwayCommand.ts
@@ -13,7 +13,7 @@ import { ICommand } from "../metar";
 export class RunwayCommand implements ICommand {
   #genericRegex = /^(R\d{2}\w?\/)/;
   #runwayMaxRangeRegex =
-    /^R(\d{2}\w?)\/(\d{4})V(\d{3,4})(?:([UDN])|(FT)(?:\/([UDN]))?)$/;
+    /^R(\d{2}\w?)\/(\d{4})V([MP])?(\d{3,4})(?:([UDN])|(FT)(?:\/([UDN]))?)$/;
   #runwayRegex = /^R(\d{2}\w?)\/([MP])?(\d{4})(?:([UDN])|(FT)(?:\/([UDN]))?)$/;
   #runwayDepositRegex = /^R(\d{2}\w?)\/([/\d])([/\d])(\/\/|\d{2})(\/\/|\d{2})$/;
 
@@ -64,18 +64,20 @@ export class RunwayCommand implements ICommand {
 
       if (!matches) throw new UnexpectedParseError("Should be able to parse");
 
+      const indicator = matches[3] ? as(matches[3], ValueIndicator) : undefined;
       const trend = (() => {
-        if (matches[6]) return as(matches[6], RunwayInfoTrend);
-        if (matches[4]) return as(matches[4], RunwayInfoTrend);
+        if (matches[7]) return as(matches[7], RunwayInfoTrend);
+        if (matches[5]) return as(matches[5], RunwayInfoTrend);
       })();
-      const unit = matches[5]
-        ? as(matches[5], RunwayInfoUnit)
+      const unit = matches[6]
+        ? as(matches[6], RunwayInfoUnit)
         : RunwayInfoUnit.Meters;
 
       metar.runwaysInfo.push({
         name: matches[1],
+        indicator,
         minRange: +matches[2],
-        maxRange: +matches[3],
+        maxRange: +matches[4],
         trend,
         unit,
       });

--- a/tests/command/metar/RunwayCommand.test.ts
+++ b/tests/command/metar/RunwayCommand.test.ts
@@ -123,6 +123,31 @@ describe("RunwayCommand", () => {
   })();
 
   (() => {
+    const code = "R08R/5000VP6000FT/D"; // runway info range north america style with indicator
+    const metar = { runwaysInfo: [] } as unknown as IMetar;
+
+    describe(code, () => {
+      test("canParse", () => {
+        expect(command.canParse(code)).toBe(true);
+      });
+
+      test("parse", () => {
+        command.execute(metar, code);
+
+        expect(metar.runwaysInfo).toHaveLength(1);
+        expect(metar.runwaysInfo[0]).toEqual({
+          name: "08R",
+          minRange: 5000,
+          maxRange: 6000,
+          indicator: ValueIndicator.GreaterThan,
+          unit: RunwayInfoUnit.Feet,
+          trend: RunwayInfoTrend.Decreasing,
+        });
+      });
+    });
+  })();
+
+  (() => {
     const code = "R01L/0800FT"; // runway info range feet simple
     const metar = { runwaysInfo: [] } as unknown as IMetar;
 


### PR DESCRIPTION
Correctly parses `R08R/5000VP6000FT/D` and setting the `indicator` field (in the example case to `ValueIndicator.GreaterThan`)

This fixes #117 